### PR TITLE
Implementation for Bluetooth classic devices not able to pair, transmit readings

### DIFF
--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -493,14 +493,18 @@ public class BluetoothSerial extends CordovaPlugin {
     }
 
     private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
+
         JSONObject json = new JSONObject();
-        json.put("name", device.getName());
-        Log.d(TAG, "************ CLASSIC DEVICE FOUND name " + device.getName());
-        json.put("address", device.getAddress());
-        Log.d(TAG, "************ CLASSIC DEVICE FOUND  address" + device.getAddress());
-        json.put("id", device.getAddress());
-        if (device.getBluetoothClass() != null) {
-            json.put("class", device.getBluetoothClass().getDeviceClass());
+        if (device!= null) {
+
+            json.put("name", device.getName());
+            Log.d(TAG, "************ CLASSIC DEVICE to be sent name " + device.getName());
+            json.put("address", device.getAddress());
+            Log.d(TAG, "************ CLASSIC DEVICE to be sent  address" + device.getAddress());
+            json.put("id", device.getAddress());
+            if (device.getBluetoothClass() != null) {
+                json.put("class", device.getBluetoothClass().getDeviceClass());
+            }
         }
         return json;
     }
@@ -739,23 +743,23 @@ public class BluetoothSerial extends CordovaPlugin {
             if (bluetoothSerialService != null) {
                 connectedDevice = bluetoothSerialService.getConnectedDevice();
                 bluetoothSerialService.resetConnectedBTDevice();
-            try {
-                o = deviceToJSON(connectedDevice);
-                res = new PluginResult(PluginResult.Status.OK, o);
-            } catch (JSONException e) {
-                e.printStackTrace();
-                res = new PluginResult(PluginResult.Status.OK);
-            }
+                try {
+                    o = deviceToJSON(connectedDevice);
+                    res = new PluginResult(PluginResult.Status.OK, o);
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                    res = new PluginResult(PluginResult.Status.OK);
+                }
 
             } else {
-            res = new PluginResult(PluginResult.Status.OK);
+               res = new PluginResult(PluginResult.Status.OK);
             }
 
              res.setKeepCallback(true);
             Log.d(TAG, "1. Notify connection success ---- " + connectCallback);
              connectCallback.sendPluginResult(res);
             Log.d(TAG, "2. Notify connection success ---- " + connectCallback);
-             // processNextEnqueuedClassicDevice();
+            
         } else {
             Log.d(TAG, "## Tried to notify success but no callback " + connectCallback);
         }

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -21,14 +21,22 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PermissionHelper;
 import org.apache.cordova.PluginResult;
-import org.apache.cordova.LOG;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaWebView;
+import android.util.Log;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import java.util.Set;
@@ -69,8 +77,6 @@ public class BluetoothSerial extends CordovaPlugin {
     private CallbackContext enableBluetoothCallback;
     private CallbackContext deviceDiscoveredCallback;
 
-    private BluetoothBroadcastReceiver actionFoundReceiver;
-
     private BluetoothAdapter bluetoothAdapter;
     private BluetoothSerialService bluetoothSerialService;
 
@@ -106,10 +112,103 @@ public class BluetoothSerial extends CordovaPlugin {
     // Android 29 and 30 permission
     private static final String ACCESS_FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
 
+    //good link
+    //https://stackoverflow.com/questions/4715865/how-can-i-programmatically-tell-if-a-bluetooth-device-is-connected
+    //https://stackoverflow.com/questions/13626277/how-to-detect-that-an-already-discovered-and-paired-device-is-available
+
+//Device discovery will only find remote devices that are currently discoverable (inquiry scan enabled). Many Bluetooth devices are not discoverable by default, and need to be entered into a special mode.
+//https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#startDiscovery()
+
+    //TRY THIS  >> bond state change one
+    //https://stackoverflow.com/questions/35239880/find-all-bluetooth-devices-headsets-phones-etc-nearby-without-forcing-the-de
+
+    BluetoothBroadcastReceiver aclConnectEventReceiver;
+
+    public void registerStateChangeReceiver(Context context) {
+        if(aclConnectEventReceiver == null) {
+            //nehal
+            IntentFilter filter = new IntentFilter();
+            filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+            filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+            aclConnectEventReceiver = new BluetoothBroadcastReceiver();
+            context.registerReceiver(aclConnectEventReceiver, filter);
+        }
+    }
+
+    /**
+     * Broadcast receiver listening to bluetooth connection and pairing actions
+     */
+    private class BluetoothBroadcastReceiver extends BroadcastReceiver {
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            try {
+                String action = intent.getAction();
+                Bundle bundle = intent.getExtras();
+
+                /* Logging of actions received for debugging purpose */
+                if (BluetoothDevice.ACTION_FOUND.equals(action) && bundle != null) {
+                    for (String key : bundle.keySet()) {
+                        Log.d(TAG, String.format("======%s :  %s--%s", action, key,
+                            bundle.get(key) != null ? Objects.requireNonNull(bundle.get(key)).toString() : "null"));
+                    }
+                }
+
+                if (action == null) return;
+
+                switch (action) {
+//                    case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
+//                        Log.d(TAG, "ACTION_BOND_STATE_CHANGED");
+//                        onPairingStateChanged(Objects.requireNonNull(bundle), intent);
+//                        break;
+
+
+                    case BluetoothDevice.ACTION_ACL_CONNECTED:
+                        if (intent != null) {
+                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                            if (device != null) {
+                                Log.d("AB", "Device CONNECTED ACL  " + device.getName());
+                            }
+                        }
+                        break;
+                    case BluetoothDevice.ACTION_ACL_DISCONNECTED:
+                        //NEHAL FINDINGS :
+                        // Even if the device is transmitting the readings and is ON, then also this event gets notfication at a very early time
+                        // when we turn on a device, state is not changing from isConnected to CONNECTING..
+                        if (intent != null) {
+                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                            if (device != null) {
+                                Log.d("AB", "Device Disconnected ACL  " + device.getName());
+                                Log.d("AB", "BT service instance " + bluetoothSerialService);
+                                Log.d("AB", "## Device " + device.getName() + " ACL Disconnected --empty the queue to start fresh");
+                                bluetoothSerialService.setStateNone();
+                                if (queuedClassicDevices != null) {
+                                    queuedClassicDevices.clear();
+
+
+                                }
+                            }
+                        }
+                    default:
+                        break;
+                }
+            } catch (Exception e) {
+                Log.d(TAG,
+                    "Exception onReceive in Device paired with the sensor" + e);
+            }
+        }
+    }
+
+     @Override
+    public void initialize(CordovaInterface cordova, CordovaWebView webView){
+         Log.d("AB", "Initialzie PLUGON & QUEUE");
+
+    }
+
     @Override
     public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
 
-        LOG.d(TAG, "action = " + action);
+        Log.d(TAG, "action = " + action);
 
         if (bluetoothAdapter == null) {
             bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
@@ -119,6 +218,11 @@ public class BluetoothSerial extends CordovaPlugin {
             bluetoothSerialService = new BluetoothSerialService(mHandler);
             registerStateChangeReceiver(cordova.getContext());
         }
+//        else {
+//            if( !bluetoothAdapter.isDiscovering()) {
+//                bluetoothAdapter.startDiscovery();
+//            }
+//        }
 
         boolean validAction = true;
 
@@ -205,11 +309,13 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(IS_CONNECTED)) {
 
-            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
-                callbackContext.success();
-            } else {
-                callbackContext.error("Not connected.");
-            }
+            callbackContext.error("Not connected.");
+
+//            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
+//                callbackContext.success();
+//            } else {
+//                callbackContext.error("Not connected.");
+//            }
 
         } else if (action.equals(CLEAR)) {
 
@@ -229,7 +335,7 @@ public class BluetoothSerial extends CordovaPlugin {
             cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
 
         } else if (action.equals(DISCOVER_UNPAIRED)) {
-
+          //  this.deviceDiscoveredCallback = null;
             if (hasBluetoothPermissions()) {
                 discoverUnpairedDevices(callbackContext);
             } else {
@@ -322,6 +428,10 @@ public class BluetoothSerial extends CordovaPlugin {
         if (bluetoothSerialService != null) {
             bluetoothSerialService.stop();
         }
+        if(aclConnectEventReceiver!=null) {
+            cordova.getActivity().unregisterReceiver(aclConnectEventReceiver);
+            aclConnectEventReceiver = null;
+        }
     }
 
     private void listBondedDevices(CallbackContext callbackContext) throws JSONException {
@@ -334,47 +444,74 @@ public class BluetoothSerial extends CordovaPlugin {
         callbackContext.success(deviceList);
     }
 
+
+
     private void discoverUnpairedDevices(final CallbackContext callbackContext) throws JSONException {
 
         final CallbackContext ddc = deviceDiscoveredCallback;
 
-        final BroadcastReceiver discoverReceiver = new BroadcastReceiver() {
 
-            private JSONArray unpairedDevices = new JSONArray();
+  final BroadcastReceiver discoverReceiver = new BroadcastReceiver() {
 
-            public void onReceive(Context context, Intent intent) {
-                String action = intent.getAction();
-                if (BluetoothDevice.ACTION_FOUND.equals(action)) {
-                    BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                    try {
-                        JSONObject o = deviceToJSON(device);
-                        unpairedDevices.put(o);
-                        if (ddc != null) {
-                            PluginResult res = new PluginResult(PluginResult.Status.OK, o);
-                            res.setKeepCallback(true);
-                            ddc.sendPluginResult(res);
-                        }
-                    } catch (JSONException e) {
-                        // This shouldn't happen, log and ignore
-                        Log.e(TAG, "Problem converting device to JSON", e);
+        private JSONArray unpairedDevices = new JSONArray();
+
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            //   Log.d("AB", "**************** ACTION ******* " + action);
+            if (BluetoothDevice.ACTION_FOUND.equals(action)) {
+                BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                Log.d("AB", "@@@@ Action FOUND " + device.getName());
+                try {
+                    JSONObject o = deviceToJSON(device);
+                    unpairedDevices.put(o);
+                    if (ddc != null) {
+                        PluginResult res = new PluginResult(PluginResult.Status.OK, o);
+                        res.setKeepCallback(true);
+                        ddc.sendPluginResult(res);
                     }
-                } else if (BluetoothAdapter.ACTION_DISCOVERY_FINISHED.equals(action)) {
-                    callbackContext.success(unpairedDevices);
-                    cordova.getActivity().unregisterReceiver(this);
+                } catch (JSONException e) {
+                    // This shouldn't happen, Log and ignore
+                    Log.e(TAG, "Problem converting device to JSON", e);
                 }
-            }
-        };
+            } else if (BluetoothAdapter.ACTION_DISCOVERY_STARTED.equals(action)) {
 
-        Activity activity = cordova.getActivity();
-        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
-        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED));
+            } else if (BluetoothAdapter.ACTION_DISCOVERY_FINISHED.equals(action)) {
+                Log.d("AB", "@@@@ FINISHED FOUND " + unpairedDevices.toString());
+               callbackContext.success(unpairedDevices);
+               cordova.getActivity().unregisterReceiver(this);
+            }
+
+
+
+            //  bluetoothSerialService.stop();
+            }
+
+    };
+
+
+    Activity activity = cordova.getActivity();
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED));
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED));
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED));
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(BluetoothDevice.ACTION_FOUND);
+
+    filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
+    activity.registerReceiver(discoverReceiver, filter);
+
         bluetoothAdapter.startDiscovery();
+
+
+
     }
 
     private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
         JSONObject json = new JSONObject();
         json.put("name", device.getName());
+        Log.d("AB", "************ CLASSIC DEVICE FOUND name " + device.getName());
         json.put("address", device.getAddress());
+        Log.d("AB", "************ CLASSIC DEVICE FOUND  address" + device.getAddress());
         json.put("id", device.getAddress());
         if (device.getBluetoothClass() != null) {
             json.put("class", device.getBluetoothClass().getDeviceClass());
@@ -382,18 +519,78 @@ public class BluetoothSerial extends CordovaPlugin {
         return json;
     }
 
-    private void connect(CordovaArgs args, boolean secure, CallbackContext callbackContext) throws JSONException {
+  static Set<ClassicDevice> queuedClassicDevices = new HashSet<ClassicDevice>();
 
-        if (Build.VERSION.SDK_INT >= 31) { // (API 31) Build.VERSION_CODE.S
+    class ClassicDevice {
+        BluetoothDevice bluetoothDevice;
+        boolean secure;
+        CallbackContext callbackContext;
+
+        public ClassicDevice(BluetoothDevice bluetoothDevice, boolean secure, CallbackContext callbackContext) {
+            this.bluetoothDevice = bluetoothDevice;
+            this.secure = secure;
+            this.callbackContext = callbackContext;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result
+                + ((bluetoothDevice.getAddress() == null) ? 0 : bluetoothDevice.getAddress().hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            final ClassicDevice other = (ClassicDevice) obj;
+            if (bluetoothDevice == null) {
+                if (other.bluetoothDevice != null)
+                    return false;
+            } else if (!bluetoothDevice.getAddress().equals(other.bluetoothDevice.getAddress()))
+                return false;
+            return true;
+        }
+
+    }
+
+    private void connect(CordovaArgs args, boolean secure, CallbackContext callbackContext) throws JSONException {
+     if (Build.VERSION.SDK_INT >= 31) { // (API 31) Build.VERSION_CODE.S
             if(!hasBluetoothPermissions()) {
                 return;
             }
         }
 
+
         String macAddress = args.getString(0);
         BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
+        Log.d("AB", "## Processing for device " + device.getName());
+        if(queuedClassicDevices.isEmpty()) {
+            Log.d("AB", "## QUEUE is empty thus connecting to the obtained device ## ");
+            if (device != null) {
+                queuedClassicDevices.add(new ClassicDevice(device, secure, callbackContext));
+            }
+               connectClassic(device, secure, callbackContext);
+        } else {
 
+            Log.d("AB", "## QUEUE is NOT ---- empty thus will ADD will wait until last device finishes good or bad ## ");
+            if(device!=null) {
+                    queuedClassicDevices.add(new ClassicDevice(device, secure, callbackContext));
+                Log.d("AB", "## QUEUE SIZE ## " + queuedClassicDevices.size());
+            }
+        }
+    }
+
+    private void connectClassic(BluetoothDevice device, boolean secure, CallbackContext callbackContext) {
+        Log.d("AB", "## Connect to classic " + device.getName());
         if (device != null) {
+
             connectCallback = callbackContext;
             bluetoothSerialService.start(device);
             bluetoothSerialService.connect(device, secure);
@@ -404,7 +601,7 @@ public class BluetoothSerial extends CordovaPlugin {
             callbackContext.sendPluginResult(result);
 
         } else {
-            callbackContext.error("Could not connect to " + macAddress);
+            callbackContext.error("Could not connect to " + device.getName());
         }
     }
 
@@ -436,7 +633,6 @@ public class BluetoothSerial extends CordovaPlugin {
                     switch (msg.arg1) {
                         case BluetoothSerialService.STATE_CONNECTED:
                             Log.i(TAG, "BluetoothSerialService.STATE_CONNECTED");
-//                            notifyConnectionSuccess("CONNECTED");
                             notifyConnectionSuccess();
                             break;
                         case BluetoothSerialService.STATE_CONNECTING:
@@ -467,27 +663,71 @@ public class BluetoothSerial extends CordovaPlugin {
     };
 
     private void notifyConnectionLost(String error) {
+        Log.d("AB", "## Notify Connection Lost ");
         if (connectCallback != null) {
             connectCallback.error(error);
             connectCallback = null;
+
+        }
+        processNextEnqueuedClassicDevice();
+    }
+
+    private void processNextEnqueuedClassicDevice() {
+        if (bluetoothSerialService!=null && (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTING
+         /*|| bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED*/)) {
+            Log.d("AB", "## Attempting to process next enqueued device but annother oneis already in connecting state --- ");
+/// Use case failing ::: if first device connects properly then this check is not allowing to connect the next device
+            // try :: whenever NONE is done, send a notification so that this code executes
+            // or try this check at start of connect method
+            // make connect method or other block/method synchronized
+        } else {
+            Log.d("AB", "## Process next enqueued classic device --- ");
+            if (!queuedClassicDevices.isEmpty()) {
+
+                Iterator<ClassicDevice> iterator = queuedClassicDevices.iterator();
+                if (iterator.hasNext()) {
+                    ClassicDevice element = iterator.next();
+                    Log.d("AB", "## Process next enqueued classic device --- " + element.bluetoothDevice.getName());
+                    connectClassic(element.bluetoothDevice, element.secure, element.callbackContext);
+                    iterator.remove();
+                } else {
+                    Log.d("AB", "## Not processing any element --- ");
+                }
+
+            }
         }
     }
 
     private void notifyConnectionSuccess() {
         if (connectCallback != null) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK); //nehal  if paired -> PAIRED; OK -> connected
-            result.setKeepCallback(true);
-            connectCallback.sendPluginResult(result);
-        }
-    }
-
-//    private void notifyConnectionSuccess(String data) {
-//        if (connectCallback != null) {
-//            PluginResult result = new PluginResult(PluginResult.Status.OK, data); //nehal  if paired -> PAIRED; OK -> connected
+//            PluginResult result = new PluginResult(PluginResult.Status.OK);
 //            result.setKeepCallback(true);
 //            connectCallback.sendPluginResult(result);
-//        }
-//    }
+
+            BluetoothDevice connectedDevice;
+            JSONObject o = null;
+            PluginResult res;
+            //nehal sending device object to which connection has been made
+            if (bluetoothSerialService != null) {
+                connectedDevice = bluetoothSerialService.getConnectedDevice();
+            try {
+                o = deviceToJSON(connectedDevice);
+                res = new PluginResult(PluginResult.Status.OK, o);
+            } catch (JSONException e) {
+                e.printStackTrace();
+                res = new PluginResult(PluginResult.Status.OK);
+            }
+
+            } else {
+            res = new PluginResult(PluginResult.Status.OK);
+            }
+
+             res.setKeepCallback(true);
+             connectCallback.sendPluginResult(res);
+             // processNextEnqueuedClassicDevice();
+        }
+
+    }
 
     private void sendRawDataToSubscriber(byte[] data) {
         if (data != null && data.length > 0) {
@@ -552,9 +792,9 @@ public class BluetoothSerial extends CordovaPlugin {
             } else {
                 // permissions not granted, disable functionality or show message
                 if (Build.VERSION.SDK_INT >= 31) {
-                    LOG.d(TAG, "User did not grant Nearby devices permission");
+                    Log.d(TAG, "User did not grant Nearby devices permission");
                 } else {
-                    LOG.d(TAG, "User did not grant location permission");
+                    Log.d(TAG, "User did not grant location permission");
                 }
             }
         } else {
@@ -562,116 +802,811 @@ public class BluetoothSerial extends CordovaPlugin {
         }
 
     }
+}
 
-        public void registerStateChangeReceiver(Context context) {
-
-
-        //nehal
-        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-        // filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
-        // filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-        // filter.addAction(BluetoothDevice.ACTION_FOUND);
-        actionFoundReceiver = new BluetoothBroadcastReceiver();
-        context.registerReceiver(actionFoundReceiver, filter);
-    }
-
-    /**
-     * Broadcast receiver listening to bluetooth connection and pairing actions
-     */
-    private class BluetoothBroadcastReceiver extends BroadcastReceiver {
-
-        @Override
-        public void onReceive(Context context, Intent intent) {
-            try {
-                String action = intent.getAction();
-                Bundle bundle = intent.getExtras();
-
-                /* Logging of actions received for debugging purpose */
-                if (!BluetoothDevice.ACTION_FOUND.equals(action) && bundle != null) {
-                    for (String key : bundle.keySet()) {
-                        Log.d(TAG, String.format("======%s :  %s--%s", action, key,
-                            bundle.get(key) != null ? Objects.requireNonNull(bundle.get(key)).toString() : "null"));
-                    }
-                }
-
-                if (action == null) return;
-
-                switch (action) {
-                    case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
-                        Log.d(TAG, "ACTION_BOND_STATE_CHANGED");
-                        onPairingStateChanged(Objects.requireNonNull(bundle), intent);
-                        break;
-
-//                    case BluetoothAdapter.ACTION_DISCOVERY_FINISHED:
-//                        Log.d(TAG, "ACTION_DISCOVERY_FINISHED");
-//                        if (isDeviceDiscoveryInProcess && mBluetoothDevice == null && !mBluetoothAdapter.isDiscovering()) {
-//                            Logger.log(true, "i", TAG, "Device was not found, restart discovery to keep trying till timeout");
-//                            mBluetoothAdapter.startDiscovery();
+//package com.megster.cordova;
+//
+//import android.Manifest;
+//import android.content.pm.PackageManager;
+//
+//import android.app.Activity;
+//import android.bluetooth.BluetoothAdapter;
+//import android.bluetooth.BluetoothDevice;
+//import android.content.BroadcastReceiver;
+//import android.content.Context;
+//import android.content.Intent;
+//import android.content.IntentFilter;
+//import android.os.Build;
+//import android.os.Bundle;
+//import android.os.Handler;
+//import android.os.Message;
+//import android.provider.Settings;
+//import android.util.Log;
+//import org.apache.cordova.CordovaArgs;
+//import org.apache.cordova.CordovaPlugin;
+//import org.apache.cordova.CallbackContext;
+//import org.apache.cordova.PermissionHelper;
+//import org.apache.cordova.PluginResult;
+//import org.apache.cordova.Log;
+//import org.json.JSONArray;
+//import org.json.JSONException;
+//import org.json.JSONObject;
+//
+//import java.io.IOException;
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Objects;
+//import java.util.concurrent.TimeUnit;
+//
+//import java.util.Set;
+//
+///**
+// * PhoneGap Plugin for Serial Communication over Bluetooth
+// */
+//public class BluetoothSerial extends CordovaPlugin {
+//
+//    // actions
+//    private static final String LIST = "list";
+//    private static final String CONNECT = "connect";
+//    private static final String CONNECT_INSECURE = "connectInsecure";
+//    private static final String DISCONNECT = "disconnect";
+//    private static final String WRITE = "write";
+//    private static final String AVAILABLE = "available";
+//    private static final String READ = "read";
+//    private static final String READ_UNTIL = "readUntil";
+//    private static final String SUBSCRIBE = "subscribe";
+//    private static final String UNSUBSCRIBE = "unsubscribe";
+//    private static final String SUBSCRIBE_RAW = "subscribeRaw";
+//    private static final String UNSUBSCRIBE_RAW = "unsubscribeRaw";
+//    private static final String IS_ENABLED = "isEnabled";
+//    private static final String IS_CONNECTED = "isConnected";
+//    private static final String CLEAR = "clear";
+//    private static final String SETTINGS = "showBluetoothSettings";
+//    private static final String ENABLE = "enable";
+//    private static final String DISCOVER_UNPAIRED = "discoverUnpaired";
+//    private static final String SET_DEVICE_DISCOVERED_LISTENER = "setDeviceDiscoveredListener";
+//    private static final String CLEAR_DEVICE_DISCOVERED_LISTENER = "clearDeviceDiscoveredListener";
+//    private static final String SET_NAME = "setName";
+//    private static final String SET_DISCOVERABLE = "setDiscoverable";
+//
+//    // callbacks
+//    private CallbackContext connectCallback;
+//    private CallbackContext dataAvailableCallback;
+//    private CallbackContext rawDataAvailableCallback;
+//    private CallbackContext enableBluetoothCallback;
+//    private CallbackContext deviceDiscoveredCallback;
+//
+//    private BluetoothBroadcastReceiver actionFoundReceiver;
+//
+//    private BluetoothAdapter bluetoothAdapter;
+//    private Map<String,BluetoothSerialService> bluetoothSerialServiceMap = new HashMap<>();
+//    private BluetoothSerialService bluetoothSerialService; //
+//    private Handler mDeviceWaitingConnectionHandler = new Handler();
+//
+//    // Debugging
+//    private static final String TAG = "AB"; //"BluetoothSerial";
+//    private static final boolean D = true;
+//
+//    // Message types sent from the BluetoothSerialService Handler
+//    public static final int MESSAGE_STATE_CHANGE = 1;
+//    public static final int MESSAGE_READ = 2;
+//    public static final int MESSAGE_WRITE = 3;
+//    public static final int MESSAGE_DEVICE_NAME = 4;
+//    public static final int MESSAGE_TOAST = 5;
+//    public static final int MESSAGE_READ_RAW = 6;
+//
+//    // Key names received from the BluetoothChatService Handler
+//    public static final String DEVICE_NAME = "device_name";
+//    public static final String TOAST = "toast";
+//
+//    StringBuffer buffer = new StringBuffer();
+//    private String delimiter;
+//    private static final int REQUEST_ENABLE_BLUETOOTH = 1;
+//
+//    // Android 23 requires user to explicitly grant permission for location to discover unpaired
+//    private static final String ACCESS_COARSE_LOCATION = Manifest.permission.ACCESS_COARSE_LOCATION;
+//    private static final int CHECK_PERMISSIONS_REQ_CODE = 2;
+//    private CallbackContext permissionCallback;
+//
+//    // Android 31 permissions
+//    private static final String BLUETOOTH_SCAN = Manifest.permission.BLUETOOTH_SCAN;
+//    private static final String BLUETOOTH_CONNECT = Manifest.permission.BLUETOOTH_CONNECT;
+//
+//    // Android 29 and 30 permission
+//    private static final String ACCESS_FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
+//
+//    @Override
+//    public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
+//
+//        Log.d(TAG, "action = " + action+ " BluetoothSerial:"+ this + " bluetoothSerialService:"+ bluetoothSerialService);
+//
+//        if (bluetoothAdapter == null) {
+//            bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+//        }
+//
+//        if (bluetoothSerialService == null) {
+//            bluetoothSerialService = new BluetoothSerialService(mHandler);
+//            registerStateChangeReceiver(cordova.getContext());
+//            Log.d("AB", "Bluetooth serial service INSTANCE " + bluetoothSerialService);
+//            Activity activity = cordova.getActivity();
+//        }
+//
+//        boolean validAction = true;
+//
+//        if (action.equals(LIST)) {
+//
+//            listBondedDevices(callbackContext);
+//
+//        } else if (action.equals(CONNECT)) {
+//
+//            boolean secure = true;
+//            connect(args, secure, callbackContext);
+//
+//        } else if (action.equals(CONNECT_INSECURE)) {
+//
+//            // see Android docs about Insecure RFCOMM http://goo.gl/1mFjZY
+//            boolean secure = false;
+//            connect(args, secure, callbackContext);
+//
+//        } else if (action.equals(DISCONNECT)) {
+//
+//            connectCallback = null;
+//            bluetoothSerialService.stop();
+//            callbackContext. onScaleDataPacket();();
+//
+//        } else if (action.equals(WRITE)) {
+//
+//            byte[] data = args.getArrayBuffer(0);
+//            bluetoothSerialService.write(data);
+//            callbackContext.success();
+//
+//        } else if (action.equals(AVAILABLE)) {
+//
+//            callbackContext.success(available());
+//
+//        } else if (action.equals(READ)) {
+//
+//            callbackContext.success(read());
+//
+//        } else if (action.equals(READ_UNTIL)) {
+//
+//            String interesting = args.getString(0);
+//            callbackContext.success(readUntil(interesting));
+//
+//        } else if (action.equals(SUBSCRIBE)) {
+//
+//            delimiter = args.getString(0);
+//            dataAvailableCallback = callbackContext;
+//
+//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+//            result.setKeepCallback(true);
+//            callbackContext.sendPluginResult(result);
+//
+//        } else if (action.equals(UNSUBSCRIBE)) {
+//
+//            delimiter = null;
+//
+//            // send no result, so Cordova won't hold onto the data available callback anymore
+//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+//            dataAvailableCallback.sendPluginResult(result);
+//            dataAvailableCallback = null;
+//
+//            callbackContext.success();
+//
+//        } else if (action.equals(SUBSCRIBE_RAW)) {
+//            rawDataAvailableCallback = callbackContext;
+//
+//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+//            result.setKeepCallback(true);
+//            callbackContext.sendPluginResult(result);
+//
+//        } else if (action.equals(UNSUBSCRIBE_RAW)) {
+//
+//            rawDataAvailableCallback = null;
+//
+//            callbackContext.success();
+//
+//        } else if (action.equals(IS_ENABLED)) {
+//
+//            if (bluetoothAdapter.isEnabled()) {
+//                callbackContext.success();
+//            } else {
+//                callbackContext.error("Bluetooth is disabled.");
+//            }
+//
+//        } else if (action.equals(IS_CONNECTED)) {
+//        // along with this check.. check that device is initialized...
+//            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
+////                if( pairedDeviceIsConnected) {
+////                    Log.d("AB", "PAIRED DEVICE IS ACTUALLY CONNECTED ");
+////                    callbackContext.success();
+////                } else {
+////                    Log.d("AB", "PAIRED DEVICE IS ***NOT**** ACTUALLY CONNECTED ");
+////                }
+////                BluetoothDevice connectedDevice;
+////                JSONObject o = null;
+////                PluginResult res;
+//                //nehal sending device object to which connection has been made
+//                if (bluetoothSerialService != null) {
+//                    if (bluetoothSerialService.getConnectedDevice() != null)
+//                        Log.d("AB", "######## Is connected " + bluetoothSerialService.getConnectedDevice().getName());
+//                }
+////                    try {
+////                        o = deviceToJSON(connectedDevice);
+////                        res = new PluginResult(PluginResult.Status.OK, o);
+////                    } catch (JSONException e) {
+////                        e.printStackTrace();
+////                        res = new PluginResult(PluginResult.Status.OK);
+////                    }
+////
+////                } else {
+////                    res = new PluginResult(PluginResult.Status.OK);
+////                }
+////
+////                res.setKeepCallback(true);
+////                connectCallback.sendPluginResult(res);
+//                callbackContext.success();
+//            } else {
+//                callbackContext.error("Not connected.");
+//            }
+//
+//        } else if (action.equals(CLEAR)) {
+//
+//            buffer.setLength(0);
+//            callbackContext.success();
+//
+//        } else if (action.equals(SETTINGS)) {
+//
+//            Intent intent = new Intent(Settings.ACTION_BLUETOOTH_SETTINGS);
+//            cordova.getActivity().startActivity(intent);
+//            callbackContext.success();
+//
+//        } else if (action.equals(ENABLE)) {
+//
+//            enableBluetoothCallback = callbackContext;
+//            Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+//            cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
+//
+//        } else if (action.equals(DISCOVER_UNPAIRED)) {
+//
+//            if (hasBluetoothPermissions()) {
+//                discoverUnpairedDevices(callbackContext);
+//            } else {
+//                permissionCallback = callbackContext;
+//                requestPermissions();
+//            }
+//
+//        } else if (action.equals(SET_DEVICE_DISCOVERED_LISTENER)) {
+//
+//            this.deviceDiscoveredCallback = callbackContext;
+//
+//        } else if (action.equals(CLEAR_DEVICE_DISCOVERED_LISTENER)) {
+//
+//            this.deviceDiscoveredCallback = null;
+//
+//        } else if (action.equals(SET_NAME)) {
+//
+//            String newName = args.getString(0);
+//            bluetoothAdapter.setName(newName);
+//            callbackContext.success();
+//
+//        } else if (action.equals(SET_DISCOVERABLE)) {
+//
+//            int discoverableDuration = args.getInt(0);
+//            Intent discoverIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
+//            discoverIntent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, discoverableDuration);
+//            cordova.getActivity().startActivity(discoverIntent);
+//
+//        } else {
+//            validAction = false;
+//
+//        }
+//
+//        return validAction;
+//    }
+//
+//    private boolean hasBluetoothPermissions() {
+//        if (Build.VERSION.SDK_INT >= 31) { // for android 12 check for Nearby devices permission
+//            return cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT);
+//        } else if (Build.VERSION.SDK_INT == 29 || Build.VERSION.SDK_INT == 30) {
+//            return cordova.hasPermission(ACCESS_FINE_LOCATION);
+//        } else {
+//            return cordova.hasPermission(ACCESS_COARSE_LOCATION);
+//        }
+//    }
+//
+//    private void requestPermissions() {
+//        //Android 12 (API 31) and higher
+//        // Users MUST accept BLUETOOTH_SCAN and BLUETOOTH_CONNECT [nearby devices]
+//        // Android 10 (API 29) up to Android 11 (API 30)
+//        // Users MUST accept ACCESS_FINE_LOCATION
+//        // Users may accept or reject ACCESS_BACKGROUND_LOCATION
+//        // Android 9 (API 28) and lower
+//        // Users MUST accept ACCESS_COARSE_LOCATION
+//
+//        if (Build.VERSION.SDK_INT >= 31) {
+//            cordova.requestPermissions(this, CHECK_PERMISSIONS_REQ_CODE, new String[]{BLUETOOTH_SCAN, BLUETOOTH_CONNECT});
+//        } else if (Build.VERSION.SDK_INT == 29 || Build.VERSION.SDK_INT == 30) {
+//            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, ACCESS_FINE_LOCATION);
+//        } else {
+//            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, ACCESS_COARSE_LOCATION);
+//        }
+//
+//    }
+//
+//    @Override
+//    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+//
+//        if (requestCode == REQUEST_ENABLE_BLUETOOTH) {
+//
+//            if (resultCode == Activity.RESULT_OK) {
+//                Log.d(TAG, "User enabled Bluetooth");
+//                if (enableBluetoothCallback != null) {
+//                    enableBluetoothCallback.success();
+//                }
+//            } else {
+//                Log.d(TAG, "User did *NOT* enable Bluetooth");
+//                if (enableBluetoothCallback != null) {
+//                    enableBluetoothCallback.error("User did not enable Bluetooth");
+//                }
+//            }
+//
+//            enableBluetoothCallback = null;
+//        }
+//    }
+//
+//    @Override
+//    public void onDestroy() {
+//        super.onDestroy();
+//        if (bluetoothSerialService != null) {
+//            bluetoothSerialService.stop();
+//        }
+//    }
+//
+//    private void listBondedDevices(CallbackContext callbackContext) throws JSONException {
+//        JSONArray deviceList = new JSONArray();
+//        Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
+//
+//        for (BluetoothDevice device : bondedDevices) {
+//            deviceList.put(deviceToJSON(device));
+//        }
+//        callbackContext.success(deviceList);
+//    }
+//
+//    private void discoverUnpairedDevices(final CallbackContext callbackContext) throws JSONException {
+//
+//        final CallbackContext ddc = deviceDiscoveredCallback;
+//
+//        final BroadcastReceiver discoverReceiver = new BroadcastReceiver() {
+//
+//            private JSONArray unpairedDevices = new JSONArray();
+//
+//            public void onReceive(Context context, Intent intent) {
+//                String action = intent.getAction();
+//                Log.d("AB", "onReceive STRIMG " + action);
+//                if (BluetoothDevice.ACTION_FOUND.equals(action)) {
+//                    BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+//                   // Log.d("AB", "Device DISCOVERED " + device.getName());
+//                    try {
+//                        JSONObject o = deviceToJSON(device);
+//                        unpairedDevices.put(o);
+//                        if (ddc != null) {
+//                            PluginResult res = new PluginResult(PluginResult.Status.OK, o);
+//                            res.setKeepCallback(true);
+//                            ddc.sendPluginResult(res);
 //                        }
-//                        mListener.onDiscoveryFinished();
+//                    } catch (JSONException e) {
+//                        // This shouldn't happen, Log and ignore
+//                        Log.e(TAG, "Problem converting device to JSON", e);
+//                    }
+//                }
+////                else if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
+////                    if(intent !=null) {
+////                        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+////                        if(device!=null) {
+////                            Log.d("AB", "Device CONNECTED ACL  " + device.getName());
+////                        }
+////                    }
+////                }
+////                else if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
+////
+////                    if(intent !=null) {
+////                        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+////                        if(device!=null) {
+////                            Log.d("AB", "Device DISSSSSS CONNECTED ACL  " + device.getName());
+////                        }
+////                    }
+////                }
+//                else if (BluetoothAdapter.ACTION_DISCOVERY_FINISHED.equals(action)) {
+//                    callbackContext.success(unpairedDevices);
+//                    cordova.getActivity().unregisterReceiver(this);
+//                }
+//            }
+//        };
+//
+//
+//        Activity activity = cordova.getActivity();
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
+//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED));
+//        //activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED));
+//        //activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED));
+//        bluetoothAdapter.startDiscovery();
+//    }
+//
+//    private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
+//        JSONObject json = new JSONObject();
+//        json.put("name", device.getName());
+//        json.put("address", device.getAddress());
+//        json.put("id", device.getAddress());
+//        if (device.getBluetoothClass() != null) {
+//            json.put("class", device.getBluetoothClass().getDeviceClass());
+//        }
+//        return json;
+//    }
+//
+//    private void connect(final CordovaArgs args, final boolean secure, final CallbackContext callbackContext) throws JSONException {
+//
+//        if (Build.VERSION.SDK_INT >= 31) { // (API 31) Build.VERSION_CODE.S
+//            if(!hasBluetoothPermissions()) {
+//                return;
+//            }
+//        }
+//
+//        String macAddress = args.getString(0);
+//        BluetoothDevice devicePassedToConnect = bluetoothAdapter.getRemoteDevice(macAddress);
+//        Log.d("AB", "---Bluetooth Service initiating to connect device---- ");
+//
+//        if(bluetoothSerialService != null){
+//            BluetoothDevice connectedbluetoothDevice = bluetoothSerialService.getConnectedDevice();
+//            Log.d("AB", "---Bluetooth Service initiating to connect NEW device " + macAddress + " name " + devicePassedToConnect.getName() +  " bluetoothSerialService: " + bluetoothSerialService.getState());
+//
+//            if (connectedbluetoothDevice != null) {
+//                Log.d("AB", "---Bluetooth Service Already Running for Device:" + connectedbluetoothDevice.getName()
+//                    + " bluetoothSerialService.getState()" + bluetoothSerialService.getState());
+//            }
+//
+//            if(connectedbluetoothDevice != null && !connectedbluetoothDevice.getAddress().equalsIgnoreCase(macAddress)) {
+//                if ((bluetoothSerialService.getState() != BluetoothSerialService.STATE_NONE /*BluetoothSerialService.STATE_CONNECTED*/)) {
+//                    Log.d("AB", "---Bluetooth Service Already connecting for a different device, so close that");
+//
+//                    mHandler.removeMessages(0);
+//
+//                        mHandler.postDelayed(() -> {
+//                            try {
+//                                BluetoothSerial.this.connect(args, secure, callbackContext);
+//                            } catch (JSONException e) {
+//                                e.printStackTrace();
+//                            }
+//                        }, 500);
+//
+//                    return;
+////                   bluetoothSerialService.stop();
+////                   bluetoothSerialService = new BluetoothSerialService(mHandler);
+//                    // this requires a bit of time... before starting a new service instance the old one needs to be cleared prperly
+//
+////                try {
+////                    //set time in mili
+////                    Thread.sleep(3000);
+////
+////                }catch (Exception e){
+////                    e.printStackTrace();
+////                }
+//                } else {
+//                    bluetoothSerialService.stop();
+//                    bluetoothSerialService = new BluetoothSerialService(mHandler);
+//                }
+//            }
+//        }
+//
+//        if (devicePassedToConnect != null) {
+//            connectCallback = callbackContext;
+//            Log.d("AB", "Calling connect and start service for device " + devicePassedToConnect.getName() + " bluetoothSerialService: " + bluetoothSerialService);
+//            bluetoothSerialService.start(devicePassedToConnect);
+//            bluetoothSerialService.connect(devicePassedToConnect, secure);
+//            buffer.setLength(0);
+//
+//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+//            result.setKeepCallback(true);
+//            callbackContext.sendPluginResult(result);
+//
+//        } else {
+//            callbackContext.error("Could not connect to " + macAddress);
+//        }
+//    }
+//
+//    // The Handler that gets information back from the BluetoothSerialService
+//    // Original code used handler for the because it was talking to the UI.
+//    // Consider replacing with normal callbacks
+//    private final Handler mHandler = new Handler() {
+//
+//        public void handleMessage(Message msg) {
+//            switch (msg.what) {
+//                case MESSAGE_READ:
+//                    String bundle = msg.obj.toString();
+//                    Log.d(TAG, bundle);
+//
+//                    if (dataAvailableCallback != null) {
+//                        sendDataToSubscriber(bundle);
+//                    }
+//
+//                    break;
+//                case MESSAGE_READ_RAW:
+//                    if (rawDataAvailableCallback != null) {
+//                        byte[] bytes = (byte[]) msg.obj;
+//                        sendRawDataToSubscriber(bytes);
+//                    }
+//                    break;
+//                case MESSAGE_STATE_CHANGE:
+//
+//                    if(D) Log.i(TAG, "MESSAGE_STATE_CHANGE: " + msg.arg1);
+//                    switch (msg.arg1) {
+//                        case BluetoothSerialService.STATE_CONNECTED:
+//                            Log.i(TAG, "BluetoothSerialService.STATE_CONNECTED");
+////                            notifyConnectionSuccess("CONNECTED");
+//                            notifyConnectionSuccess();
+//                            break;
+//                        case BluetoothSerialService.STATE_CONNECTING:
+//                            Log.i(TAG, "BluetoothSerialService.STATE_CONNECTING");
+//                            break;
+//                        case BluetoothSerialService.STATE_LISTEN:
+//                            Log.i(TAG, "BluetoothSerialService.STATE_LISTEN");
+//                            break;
+//                        case BluetoothSerialService.STATE_NONE:
+//                            Log.i(TAG, "BluetoothSerialService.STATE_NONE");
+//                            break;
+//                    }
+//                    break;
+//                case MESSAGE_WRITE:
+//                    byte[] writeBuf = (byte[]) msg.obj;
+//                    String writeMessage = new String(writeBuf);
+//                    Log.i(TAG, "Wrote: " + writeMessage);
+//                    break;
+//                case MESSAGE_DEVICE_NAME:
+//                    Log.i(TAG, msg.getData().getString(DEVICE_NAME));
+//                    break;
+//                case MESSAGE_TOAST:
+//                    String message = msg.getData().getString(TOAST);
+//                    notifyConnectionLost(message);
+//                    break;
+//            }
+//        }
+//    };
+//
+//    private void notifyConnectionLost(String error) {
+//        if (connectCallback != null) {
+//            connectCallback.error(error);
+//            connectCallback = null;
+//        }
+//    }
+//
+//    private void notifyConnectionSuccess() {
+//        if (connectCallback != null) {
+//
+////            PluginResult result = new PluginResult(PluginResult.Status.OK); //nehal  if paired -> PAIRED; OK -> connected
+////            result.setKeepCallback(true);
+////            connectCallback.sendPluginResult(result);
+//
+//            BluetoothDevice connectedDevice;
+//            JSONObject o = null;
+//            PluginResult res;
+//            //nehal sending device object to which connection has been made
+//            if (bluetoothSerialService != null) {
+//                connectedDevice = bluetoothSerialService.getConnectedDevice();
+//            try {
+//                o = deviceToJSON(connectedDevice);
+//                res = new PluginResult(PluginResult.Status.OK, o);
+//            } catch (JSONException e) {
+//                e.printStackTrace();
+//                res = new PluginResult(PluginResult.Status.OK);
+//            }
+//
+//            } else {
+//            res = new PluginResult(PluginResult.Status.OK);
+//            }
+//
+//             res.setKeepCallback(true);
+//             connectCallback.sendPluginResult(res);
+//
+//        }
+//    }
+//
+////    private void notifyConnectionSuccess(String data) {
+////        if (connectCallback != null) {
+////            PluginResult result = new PluginResult(PluginResult.Status.OK, data); //nehal  if paired -> PAIRED; OK -> connected
+////            result.setKeepCallback(true);
+////            connectCallback.sendPluginResult(result);
+////        }
+////    }
+//
+//    private void sendRawDataToSubscriber(byte[] data) {
+//        if (data != null && data.length > 0) {
+//            PluginResult result = new PluginResult(PluginResult.Status.OK, data);
+//            result.setKeepCallback(true);
+//            rawDataAvailableCallback.sendPluginResult(result);
+//        }
+//    }
+//
+//    private void sendDataToSubscriber(String data) {
+//        if (data != null) {
+//            PluginResult result = new PluginResult(PluginResult.Status.OK, data);
+//            result.setKeepCallback(true);
+//            dataAvailableCallback.sendPluginResult(result);
+//        }
+//    }
+//
+//    private int available() {
+//        return buffer.length();
+//    }
+//
+//    private String read() {
+//        int length = buffer.length();
+//        String data = buffer.substring(0, length);
+//        buffer.delete(0, length);
+//        return data;
+//    }
+//
+//    private String readUntil(String c) {
+//        String data = "";
+//        int index = buffer.indexOf(c, 0);
+//        if (index > -1) {
+//            data = buffer.substring(0, index + c.length());
+//            buffer.delete(0, index + c.length());
+//        }
+//        return data;
+//    }
+//
+//
+//    private  boolean verifyPermissions(int[] grantResults) {
+//        // At least one result must be checked.
+//        if(grantResults.length < 1){
+//            return false;
+//        }
+//        // Verify that each required permission has been granted, otherwise return false.
+//        for (int result : grantResults) {
+//            if (result != PackageManager.PERMISSION_GRANTED) {
+//                return false;
+//            }
+//        }
+//        return true;
+//    }
+//
+//    @Override
+//    public void onRequestPermissionResult(int requestCode, String[] permissions,
+//                                          int[] grantResults) throws JSONException {
+//
+//        if (requestCode == CHECK_PERMISSIONS_REQ_CODE) {
+//            if (verifyPermissions(grantResults)) {
+//                discoverUnpairedDevices(permissionCallback);
+//                this.permissionCallback = null;
+//            } else {
+//                // permissions not granted, disable functionality or show message
+//                if (Build.VERSION.SDK_INT >= 31) {
+//                    Log.d(TAG, "User did not grant Nearby devices permission");
+//                } else {
+//                    Log.d(TAG, "User did not grant location permission");
+//                }
+//            }
+//        } else {
+//            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+//        }
+//
+//    }
+//
+//    public void registerStateChangeReceiver(Context context) {
+//        if(actionFoundReceiver == null) {
+//            //nehal
+//            IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+//            filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+//            filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+//            actionFoundReceiver = new BluetoothBroadcastReceiver();
+//            context.registerReceiver(actionFoundReceiver, filter);
+//        }
+//    }
+//
+//    /**
+//     * Broadcast receiver listening to bluetooth connection and pairing actions
+//     */
+//    private class BluetoothBroadcastReceiver extends BroadcastReceiver {
+//
+//        @Override
+//        public void onReceive(Context context, Intent intent) {
+//            try {
+//                String action = intent.getAction();
+//                Bundle bundle = intent.getExtras();
+//
+//                /* Logging of actions received for debugging purpose */
+//                if (BluetoothDevice.ACTION_FOUND.equals(action) && bundle != null) {
+//                    for (String key : bundle.keySet()) {
+//                        Log.d(TAG, String.format("======%s :  %s--%s", action, key,
+//                            bundle.get(key) != null ? Objects.requireNonNull(bundle.get(key)).toString() : "null"));
+//                    }
+//                }
+//
+//                if (action == null) return;
+//
+//                switch (action) {
+//                    case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
+//                        Log.d(TAG, "ACTION_BOND_STATE_CHANGED");
+//                        onPairingStateChanged(Objects.requireNonNull(bundle), intent);
 //                        break;
 //
 //                    case BluetoothDevice.ACTION_FOUND:
-//                        onDeviceFound(intent);
 //                        break;
-                    default:
-                        break;
-                }
-            } catch (Exception e) {
-                Log.d(TAG,
-                    "Exception onReceive in Device paired with the sensor" + e);
-                //    cancelDeviceDiscovery();
-                //    mListener.onPairingError(FailureReason.EXCEPTION);
-            }
-        }
-BluetoothDevice mBluetoothDevice;
-        /**
-         * Handling of pairing/bonding state changes action
-         * BOND_NONE       --> BOND_BONDING: Pairing started
-         * BOND_BONDING    --> BOND_NONE   : Pairing error, as pairing was not completed to BOND_BONDED status
-         * BOND_BONDING    --> BOND_BONDED : Pairing completed
-         *
-         * @param bundle broadcast bundle
-         **/
-        private void onPairingStateChanged(Bundle bundle, Intent intent) {
-            if(mBluetoothDevice==null){
-                mBluetoothDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-            }
-            int newBondState = bundle.getInt(BluetoothDevice.EXTRA_BOND_STATE);
-            int previousBondState = bundle.getInt(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE);
-            Log.d(TAG, "Previous bond state: " + previousBondState + " ---> New bond state: " + newBondState);
-            String deviceInfoLog =  " | " + mBluetoothDevice.getName() + "| MACId: " + mBluetoothDevice.getAddress();
-            switch (newBondState) {
-                case BluetoothDevice.BOND_NONE:
-                    /* Possible pairing failed case as Pairing state changed from BOND_BONDING to BOND_NONE */
-                    if (previousBondState == BluetoothDevice.BOND_BONDING) {
-                        Log.d(TAG, "********** Possible pairing failed as pairing state changed from BOND_BONDING to BOND_NONE **********");
-                       // cancelDeviceDiscovery();
-                        //  mListener.onPairingError(FailureReason.FAILED);
-                    }
-                    break;
-
-                case BluetoothDevice.BOND_BONDING:
-                    /* Pairing started for device, start a timeout handler */
-                    Log.d(TAG, "********** Pairing Initiated with Device :" + deviceInfoLog + " **********");
-                    // mListener.onPairingStarted();
-                    break;
-
-                case BluetoothDevice.BOND_BONDED:
-                    Log.d(TAG, "********** Device paired successfully :" + deviceInfoLog + "  **********");
-                    //  cancelDeviceDiscovery();
-                    onPairingCompleted();
-                   // notifyConnectionSuccess("PAIRED");
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        protected void onPairingCompleted(){
-            /* Device pairing completed */
-            //mListener.onPairingSuccess();
-        }
-
-    }
-}
+//
+//                    case BluetoothDevice.ACTION_ACL_CONNECTED:
+//                        if(intent !=null) {
+//                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+//                            if(device!=null) {
+//                                Log.d("AB", "Device CONNECTED ACL  " + device.getName());
+//                            }
+//                        }
+//                        break;
+//                    case BluetoothDevice.ACTION_ACL_DISCONNECTED:
+//                        //NEHAL FINDINGS :
+//                        // Even if the device is transmitting the readings and is ON, then also this event gets notfication at a very early time
+//                        // when we turn on a device, state is not changing from isConnected to CONNECTING..
+//                        if(intent !=null) {
+//                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+//                            if(device!=null) {
+//                                Log.d("AB", "Device Disconnected ACL  " + device.getName());
+//                                Log.d("AB", "BT service instance " + bluetoothSerialService);
+//                                 bluetoothSerialService.setStateNone();
+//                            }
+//                        }
+//                    default:
+//                        break;
+//                }
+//            } catch (Exception e) {
+//                Log.d(TAG,
+//                    "Exception onReceive in Device paired with the sensor" + e);
+//            }
+//        }
+//
+//        BluetoothDevice mBluetoothDevice;
+//        /**
+//         * Handling of pairing/bonding state changes action
+//         * BOND_NONE       --> BOND_BONDING: Pairing started
+//         * BOND_BONDING    --> BOND_NONE   : Pairing error, as pairing was not completed to BOND_BONDED status
+//         * BOND_BONDING    --> BOND_BONDED : Pairing completed
+//         *
+//         * @param bundle broadcast bundle
+//         **/
+//        private void onPairingStateChanged(Bundle bundle, Intent intent) {
+//            if(mBluetoothDevice==null){
+//                mBluetoothDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+//            }
+//            int newBondState = bundle.getInt(BluetoothDevice.EXTRA_BOND_STATE);
+//            int previousBondState = bundle.getInt(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE);
+//            Log.d(TAG, "Previous bond state: " + previousBondState + " ---> New bond state: " + newBondState);
+//            String deviceInfoLog =  " | " + mBluetoothDevice.getName() + "| MACId: " + mBluetoothDevice.getAddress();
+//            switch (newBondState) {
+//                case BluetoothDevice.BOND_NONE:
+//                    /* Possible pairing failed case as Pairing state changed from BOND_BONDING to BOND_NONE */
+//                    if (previousBondState == BluetoothDevice.BOND_BONDING) {
+//                        Log.d(TAG, "********** Possible pairing failed as pairing state changed from BOND_BONDING to BOND_NONE **********");
+//                       // cancelDeviceDiscovery();
+//                        //  mListener.onPairingError(FailureReason.FAILED);
+//                    }
+//                    break;
+//
+//                case BluetoothDevice.BOND_BONDING:
+//                    /* Pairing started for device, start a timeout handler */
+//                    Log.d(TAG, "********** Pairing Initiated with Device :" + deviceInfoLog + " **********");
+//                    // mListener.onPairingStarted();
+//                    break;
+//
+//                case BluetoothDevice.BOND_BONDED:
+//                    Log.d(TAG, "********** Device paired successfully :" + deviceInfoLog + "  **********");
+//                    //  cancelDeviceDiscovery();
+////                    onPairingCompleted();
+//                   // notifyConnectionSuccess("PAIRED");
+//                    break;
+//                default:
+//                    break;
+//            }
+//        }
+//
+//    }
+//}

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -114,21 +114,12 @@ public class BluetoothSerial extends CordovaPlugin {
     // Android 29 and 30 permission
     private static final String ACCESS_FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
 
-    //good link
-    //https://stackoverflow.com/questions/4715865/how-can-i-programmatically-tell-if-a-bluetooth-device-is-connected
-    //https://stackoverflow.com/questions/13626277/how-to-detect-that-an-already-discovered-and-paired-device-is-available
-
-//Device discovery will only find remote devices that are currently discoverable (inquiry scan enabled). Many Bluetooth devices are not discoverable by default, and need to be entered into a special mode.
-//https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#startDiscovery()
-
-    //TRY THIS  >> bond state change one
-    //https://stackoverflow.com/questions/35239880/find-all-bluetooth-devices-headsets-phones-etc-nearby-without-forcing-the-de
-
-    BluetoothBroadcastReceiver aclConnectEventReceiver;
+    private BluetoothBroadcastReceiver aclConnectEventReceiver;
+    private static Set<ClassicDevice> queuedClassicDevices = new LinkedHashSet<ClassicDevice>();
 
     public void registerStateChangeReceiver(Context context) {
         if(aclConnectEventReceiver == null) {
-            //nehal
+
             IntentFilter filter = new IntentFilter();
             filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
             filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
@@ -169,24 +160,22 @@ public class BluetoothSerial extends CordovaPlugin {
                         if (intent != null) {
                             BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
                             if (device != null) {
-                                Log.d("AB", "Device CONNECTED ACL  " + device.getName());
+                                Log.d(TAG, "Device CONNECTED ACL  " + device.getName());
                             }
                         }
                         break;
                     case BluetoothDevice.ACTION_ACL_DISCONNECTED:
-                        //NEHAL FINDINGS :
+
                         // Even if the device is transmitting the readings and is ON, then also this event gets notfication at a very early time
                         // when we turn on a device, state is not changing from isConnected to CONNECTING..
                         if (intent != null) {
                             BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
                             if (device != null) {
-                                Log.d("AB", "Device Disconnected ACL  " + device.getName());
-                                Log.d("AB", "BT service instance " + bluetoothSerialService);
-                                Log.d("AB", "## Device " + device.getName() + " ACL Disconnected --empty the queue to start fresh");
+                                Log.d(TAG, "Device Disconnected ACL  " + device.getName());
+                                Log.d(TAG, "BT service instance " + bluetoothSerialService);
+                                Log.d(TAG, "## Device " + device.getName() + " ACL Disconnected --empty the queue to start fresh");
                                  bluetoothSerialService.setStateNone();
-//                                if (queuedClassicDevices != null) {
-//                                    queuedClassicDevices.clear();
-//                                }
+
                                 if(queuedClassicDevices!=null) {
                                     processNextEnqueuedClassicDevice();
                                 }
@@ -221,11 +210,6 @@ public class BluetoothSerial extends CordovaPlugin {
             bluetoothSerialService = new BluetoothSerialService(mHandler);
             registerStateChangeReceiver(cordova.getContext());
         }
-//        else {
-//            if( !bluetoothAdapter.isDiscovering()) {
-//                bluetoothAdapter.startDiscovery();
-//            }
-//        }
 
         boolean validAction = true;
 
@@ -246,9 +230,6 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(DISCONNECT)) {
 
-//            connectCallback = null;
-//            bluetoothSerialService.stop();
-//            callbackContext.success();
             disconnect(callbackContext);
 
         } else if (action.equals(WRITE)) {
@@ -313,13 +294,11 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(IS_CONNECTED)) {
 
-            callbackContext.error("Not connected.");
-
-//            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
-//                callbackContext.success();
-//            } else {
-//                callbackContext.error("Not connected.");
-//            }
+            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
+                callbackContext.success();
+            } else {
+                callbackContext.error("Not connected.");
+            }
 
         } else if (action.equals(CLEAR)) {
 
@@ -382,11 +361,6 @@ public class BluetoothSerial extends CordovaPlugin {
         connectCallback = null;
         bluetoothSerialService.stop();
         callbackContext.success();
-
-//        if(queuedClassicDevices!=null) {
-//            Log.d("AB", "## DISCONNECT event -- clearing the queue");
-//            queuedClassicDevices.clear();
-//        }
 
     }
     private boolean hasBluetoothPermissions() {
@@ -498,19 +472,12 @@ public class BluetoothSerial extends CordovaPlugin {
                cordova.getActivity().unregisterReceiver(this);
             }
 
-
-
-            //  bluetoothSerialService.stop();
             }
 
     };
 
 
     Activity activity = cordova.getActivity();
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED));
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED));
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED));
     IntentFilter filter = new IntentFilter();
     filter.addAction(BluetoothDevice.ACTION_FOUND);
 
@@ -526,9 +493,9 @@ public class BluetoothSerial extends CordovaPlugin {
     private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
         JSONObject json = new JSONObject();
         json.put("name", device.getName());
-        Log.d("AB", "************ CLASSIC DEVICE FOUND name " + device.getName());
+        Log.d(TAG, "************ CLASSIC DEVICE FOUND name " + device.getName());
         json.put("address", device.getAddress());
-        Log.d("AB", "************ CLASSIC DEVICE FOUND  address" + device.getAddress());
+        Log.d(TAG, "************ CLASSIC DEVICE FOUND  address" + device.getAddress());
         json.put("id", device.getAddress());
         if (device.getBluetoothClass() != null) {
             json.put("class", device.getBluetoothClass().getDeviceClass());
@@ -536,9 +503,6 @@ public class BluetoothSerial extends CordovaPlugin {
         return json;
     }
 
-   //static Set<ClassicDevice> queuedClassicDevices = new HashSet<ClassicDevice>();
-  // static Set<ClassicDevice> queuedClassicDevices = new TreeSet<ClassicDevice>();
-   static Set<ClassicDevice> queuedClassicDevices = new LinkedHashSet<ClassicDevice>();
 
     class ClassicDevice implements Comparable<ClassicDevice> {
         BluetoothDevice bluetoothDevice;
@@ -594,49 +558,58 @@ public class BluetoothSerial extends CordovaPlugin {
 
         String macAddress = args.getString(0);
         BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
-        Log.d("AB", "## Processing incoming connect for device " + device.getName());
+        Log.d(TAG, "## Processing incoming connect for device " + device.getName());
         Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
+        synchronized (queuedClassicDevices) {
         if(!bondedDevices.contains(device)) {
-            Log.d("AB", "This is a device which has requested to pair --- ");
-            Log.d("AB", "Clearing the queue");
+            Log.d(TAG, "This is a device which has requested to pair --- ");
+            Log.d(TAG, "Clearing the queue for polling while pairing");
             queuedClassicDevices.clear();
             bluetoothSerialService.stop();
         }
 
         if (bluetoothSerialService!=null && (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTING
             || bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED)) {
-            Log.d("AB", "## Service already connecting so do nothing");
+            Log.d(TAG, "## Service already connecting so do nothing");
             //bluetoothSerialService.restartSPPAcceptThread(device);
         } else {
             if (queuedClassicDevices.isEmpty()) {
-                Log.d("AB", "## QUEUE is empty thus connecting to the obtained device ## ");
+                Log.d(TAG, "## QUEUE is empty thus connecting to the obtained device ## ");
                 if (device != null) {
-                    if(! isNextQueueEntryUnderProcess) { //concurrent modification
-                        Log.d("AB", "## Added to queue ");
+                    if (!isNextQueueEntryUnderProcess) { //concurrent modification
+                        Log.d(TAG, "## Added to queue ");
                         queuedClassicDevices.add(new ClassicDevice(device, secure, callbackContext));
-                    }else {
-                        Log.d("AB", "## Concurrent modification avoidded");
+                    } else {
+                        Log.d(TAG, "## Concurrent modification avoidded");
                     }
                 }
                 connectClassic(device, secure, callbackContext);
             } else {
 
-                Log.d("AB", "## QUEUE is NOT ---- empty thus will ADD will wait until last device finishes good or bad ## ");
+                Log.d(TAG, "## QUEUE is NOT ---- empty thus will ADD will wait until last device finishes good or bad ## ");
                 if (device != null) {
-                    if(! isNextQueueEntryUnderProcess) { //concurrent modification
-                        Log.d("AB", "## Added to queue ");
+                    if (!isNextQueueEntryUnderProcess) { //concurrent modification
+                        Log.d(TAG, "## Added to queue ");
                         queuedClassicDevices.add(new ClassicDevice(device, secure, callbackContext));
-                    }else {
-                        Log.d("AB", "## Concurrent modification avoidded");
+                    } else {
+                        Log.d(TAG, "## Concurrent modification avoidded");
                     }
-                    Log.d("AB", "## QUEUE SIZE ## " + queuedClassicDevices.size());
+                    Log.d(TAG, "## QUEUE SIZE ## " + queuedClassicDevices.size());
                 }
             }
+        }
         }
     }
 
     private synchronized void connectClassic(BluetoothDevice device, boolean secure, CallbackContext callbackContext) {
-        Log.d("AB", "## Connect to classic " + device.getName());
+        mHandler.removeMessages(0);
+
+         mHandler.postDelayed(() -> {
+             Log.d(TAG, "## $$$$$$ Handler called the connect method $$$$$$ ");
+                           processNextEnqueuedClassicDevice();
+                        }, 15000);
+
+        Log.d(TAG, "## Connect to classic " + device.getName());
         if (device != null) {
 
             connectCallback = callbackContext;
@@ -734,36 +707,35 @@ public class BluetoothSerial extends CordovaPlugin {
             // make connect method or other block/method synchronized
       //  } else {
             Log.d("AB", "## Process next enqueued classic device --- ");
-            if (!queuedClassicDevices.isEmpty()) {
-                isNextQueueEntryUnderProcess = true;
-                Iterator<ClassicDevice> iterator = queuedClassicDevices.iterator();
-                if (iterator.hasNext()) {
+            synchronized (queuedClassicDevices) {
+                if (!queuedClassicDevices.isEmpty()) {
+                    isNextQueueEntryUnderProcess = true;
+                    Iterator<ClassicDevice> iterator = queuedClassicDevices.iterator();
+                    if (iterator.hasNext()) {
 
-                    ClassicDevice element = iterator.next();
-                    Log.d("AB", "## Process next enqueued classic device --- " + element.bluetoothDevice.getName());
-                    connectClassic(element.bluetoothDevice, element.secure, element.callbackContext);
+                        ClassicDevice element = iterator.next();
+                        Log.d("AB", "## Process next enqueued classic device --- " + element.bluetoothDevice.getName());
+                        connectClassic(element.bluetoothDevice, element.secure, element.callbackContext);
 
-                    iterator.remove();
-                    isNextQueueEntryUnderProcess = false;
-                } else {
-                    Log.d("AB", "## Not processing any element --- ");
-                    isNextQueueEntryUnderProcess = false;
+                        iterator.remove();
+                        isNextQueueEntryUnderProcess = false;
+                    } else {
+                        Log.d("AB", "## Not processing any element --- ");
+                        isNextQueueEntryUnderProcess = false;
+                    }
+
                 }
-
             }
      //   }
     }
 
     private void notifyConnectionSuccess() {
         if (connectCallback != null) {
-//            PluginResult result = new PluginResult(PluginResult.Status.OK);
-//            result.setKeepCallback(true);
-//            connectCallback.sendPluginResult(result);
 
             BluetoothDevice connectedDevice;
             JSONObject o = null;
             PluginResult res;
-            //nehal sending device object to which connection has been made
+            // sending device object to which connection has been made
             if (bluetoothSerialService != null) {
                 connectedDevice = bluetoothSerialService.getConnectedDevice();
             try {
@@ -779,12 +751,12 @@ public class BluetoothSerial extends CordovaPlugin {
             }
 
              res.setKeepCallback(true);
-            Log.d("AB", "1. Notify connection success ---- " + connectCallback);
+            Log.d(TAG, "1. Notify connection success ---- " + connectCallback);
              connectCallback.sendPluginResult(res);
-            Log.d("AB", "2. Notify connection success ---- " + connectCallback);
+            Log.d(TAG, "2. Notify connection success ---- " + connectCallback);
              // processNextEnqueuedClassicDevice();
         } else {
-            Log.d("AB", "## Tried to notify success but no callback " + connectCallback);
+            Log.d(TAG, "## Tried to notify success but no callback " + connectCallback);
         }
 
     }
@@ -863,810 +835,3 @@ public class BluetoothSerial extends CordovaPlugin {
 
     }
 }
-
-//package com.megster.cordova;
-//
-//import android.Manifest;
-//import android.content.pm.PackageManager;
-//
-//import android.app.Activity;
-//import android.bluetooth.BluetoothAdapter;
-//import android.bluetooth.BluetoothDevice;
-//import android.content.BroadcastReceiver;
-//import android.content.Context;
-//import android.content.Intent;
-//import android.content.IntentFilter;
-//import android.os.Build;
-//import android.os.Bundle;
-//import android.os.Handler;
-//import android.os.Message;
-//import android.provider.Settings;
-//import android.util.Log;
-//import org.apache.cordova.CordovaArgs;
-//import org.apache.cordova.CordovaPlugin;
-//import org.apache.cordova.CallbackContext;
-//import org.apache.cordova.PermissionHelper;
-//import org.apache.cordova.PluginResult;
-//import org.apache.cordova.Log;
-//import org.json.JSONArray;
-//import org.json.JSONException;
-//import org.json.JSONObject;
-//
-//import java.io.IOException;
-//import java.util.ArrayList;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.Objects;
-//import java.util.concurrent.TimeUnit;
-//
-//import java.util.Set;
-//
-///**
-// * PhoneGap Plugin for Serial Communication over Bluetooth
-// */
-//public class BluetoothSerial extends CordovaPlugin {
-//
-//    // actions
-//    private static final String LIST = "list";
-//    private static final String CONNECT = "connect";
-//    private static final String CONNECT_INSECURE = "connectInsecure";
-//    private static final String DISCONNECT = "disconnect";
-//    private static final String WRITE = "write";
-//    private static final String AVAILABLE = "available";
-//    private static final String READ = "read";
-//    private static final String READ_UNTIL = "readUntil";
-//    private static final String SUBSCRIBE = "subscribe";
-//    private static final String UNSUBSCRIBE = "unsubscribe";
-//    private static final String SUBSCRIBE_RAW = "subscribeRaw";
-//    private static final String UNSUBSCRIBE_RAW = "unsubscribeRaw";
-//    private static final String IS_ENABLED = "isEnabled";
-//    private static final String IS_CONNECTED = "isConnected";
-//    private static final String CLEAR = "clear";
-//    private static final String SETTINGS = "showBluetoothSettings";
-//    private static final String ENABLE = "enable";
-//    private static final String DISCOVER_UNPAIRED = "discoverUnpaired";
-//    private static final String SET_DEVICE_DISCOVERED_LISTENER = "setDeviceDiscoveredListener";
-//    private static final String CLEAR_DEVICE_DISCOVERED_LISTENER = "clearDeviceDiscoveredListener";
-//    private static final String SET_NAME = "setName";
-//    private static final String SET_DISCOVERABLE = "setDiscoverable";
-//
-//    // callbacks
-//    private CallbackContext connectCallback;
-//    private CallbackContext dataAvailableCallback;
-//    private CallbackContext rawDataAvailableCallback;
-//    private CallbackContext enableBluetoothCallback;
-//    private CallbackContext deviceDiscoveredCallback;
-//
-//    private BluetoothBroadcastReceiver actionFoundReceiver;
-//
-//    private BluetoothAdapter bluetoothAdapter;
-//    private Map<String,BluetoothSerialService> bluetoothSerialServiceMap = new HashMap<>();
-//    private BluetoothSerialService bluetoothSerialService; //
-//    private Handler mDeviceWaitingConnectionHandler = new Handler();
-//
-//    // Debugging
-//    private static final String TAG = "AB"; //"BluetoothSerial";
-//    private static final boolean D = true;
-//
-//    // Message types sent from the BluetoothSerialService Handler
-//    public static final int MESSAGE_STATE_CHANGE = 1;
-//    public static final int MESSAGE_READ = 2;
-//    public static final int MESSAGE_WRITE = 3;
-//    public static final int MESSAGE_DEVICE_NAME = 4;
-//    public static final int MESSAGE_TOAST = 5;
-//    public static final int MESSAGE_READ_RAW = 6;
-//
-//    // Key names received from the BluetoothChatService Handler
-//    public static final String DEVICE_NAME = "device_name";
-//    public static final String TOAST = "toast";
-//
-//    StringBuffer buffer = new StringBuffer();
-//    private String delimiter;
-//    private static final int REQUEST_ENABLE_BLUETOOTH = 1;
-//
-//    // Android 23 requires user to explicitly grant permission for location to discover unpaired
-//    private static final String ACCESS_COARSE_LOCATION = Manifest.permission.ACCESS_COARSE_LOCATION;
-//    private static final int CHECK_PERMISSIONS_REQ_CODE = 2;
-//    private CallbackContext permissionCallback;
-//
-//    // Android 31 permissions
-//    private static final String BLUETOOTH_SCAN = Manifest.permission.BLUETOOTH_SCAN;
-//    private static final String BLUETOOTH_CONNECT = Manifest.permission.BLUETOOTH_CONNECT;
-//
-//    // Android 29 and 30 permission
-//    private static final String ACCESS_FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
-//
-//    @Override
-//    public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
-//
-//        Log.d(TAG, "action = " + action+ " BluetoothSerial:"+ this + " bluetoothSerialService:"+ bluetoothSerialService);
-//
-//        if (bluetoothAdapter == null) {
-//            bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-//        }
-//
-//        if (bluetoothSerialService == null) {
-//            bluetoothSerialService = new BluetoothSerialService(mHandler);
-//            registerStateChangeReceiver(cordova.getContext());
-//            Log.d("AB", "Bluetooth serial service INSTANCE " + bluetoothSerialService);
-//            Activity activity = cordova.getActivity();
-//        }
-//
-//        boolean validAction = true;
-//
-//        if (action.equals(LIST)) {
-//
-//            listBondedDevices(callbackContext);
-//
-//        } else if (action.equals(CONNECT)) {
-//
-//            boolean secure = true;
-//            connect(args, secure, callbackContext);
-//
-//        } else if (action.equals(CONNECT_INSECURE)) {
-//
-//            // see Android docs about Insecure RFCOMM http://goo.gl/1mFjZY
-//            boolean secure = false;
-//            connect(args, secure, callbackContext);
-//
-//        } else if (action.equals(DISCONNECT)) {
-//
-//            connectCallback = null;
-//            bluetoothSerialService.stop();
-//            callbackContext. onScaleDataPacket();();
-//
-//        } else if (action.equals(WRITE)) {
-//
-//            byte[] data = args.getArrayBuffer(0);
-//            bluetoothSerialService.write(data);
-//            callbackContext.success();
-//
-//        } else if (action.equals(AVAILABLE)) {
-//
-//            callbackContext.success(available());
-//
-//        } else if (action.equals(READ)) {
-//
-//            callbackContext.success(read());
-//
-//        } else if (action.equals(READ_UNTIL)) {
-//
-//            String interesting = args.getString(0);
-//            callbackContext.success(readUntil(interesting));
-//
-//        } else if (action.equals(SUBSCRIBE)) {
-//
-//            delimiter = args.getString(0);
-//            dataAvailableCallback = callbackContext;
-//
-//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-//            result.setKeepCallback(true);
-//            callbackContext.sendPluginResult(result);
-//
-//        } else if (action.equals(UNSUBSCRIBE)) {
-//
-//            delimiter = null;
-//
-//            // send no result, so Cordova won't hold onto the data available callback anymore
-//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-//            dataAvailableCallback.sendPluginResult(result);
-//            dataAvailableCallback = null;
-//
-//            callbackContext.success();
-//
-//        } else if (action.equals(SUBSCRIBE_RAW)) {
-//            rawDataAvailableCallback = callbackContext;
-//
-//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-//            result.setKeepCallback(true);
-//            callbackContext.sendPluginResult(result);
-//
-//        } else if (action.equals(UNSUBSCRIBE_RAW)) {
-//
-//            rawDataAvailableCallback = null;
-//
-//            callbackContext.success();
-//
-//        } else if (action.equals(IS_ENABLED)) {
-//
-//            if (bluetoothAdapter.isEnabled()) {
-//                callbackContext.success();
-//            } else {
-//                callbackContext.error("Bluetooth is disabled.");
-//            }
-//
-//        } else if (action.equals(IS_CONNECTED)) {
-//        // along with this check.. check that device is initialized...
-//            if (bluetoothSerialService.getState() == BluetoothSerialService.STATE_CONNECTED) {
-////                if( pairedDeviceIsConnected) {
-////                    Log.d("AB", "PAIRED DEVICE IS ACTUALLY CONNECTED ");
-////                    callbackContext.success();
-////                } else {
-////                    Log.d("AB", "PAIRED DEVICE IS ***NOT**** ACTUALLY CONNECTED ");
-////                }
-////                BluetoothDevice connectedDevice;
-////                JSONObject o = null;
-////                PluginResult res;
-//                //nehal sending device object to which connection has been made
-//                if (bluetoothSerialService != null) {
-//                    if (bluetoothSerialService.getConnectedDevice() != null)
-//                        Log.d("AB", "######## Is connected " + bluetoothSerialService.getConnectedDevice().getName());
-//                }
-////                    try {
-////                        o = deviceToJSON(connectedDevice);
-////                        res = new PluginResult(PluginResult.Status.OK, o);
-////                    } catch (JSONException e) {
-////                        e.printStackTrace();
-////                        res = new PluginResult(PluginResult.Status.OK);
-////                    }
-////
-////                } else {
-////                    res = new PluginResult(PluginResult.Status.OK);
-////                }
-////
-////                res.setKeepCallback(true);
-////                connectCallback.sendPluginResult(res);
-//                callbackContext.success();
-//            } else {
-//                callbackContext.error("Not connected.");
-//            }
-//
-//        } else if (action.equals(CLEAR)) {
-//
-//            buffer.setLength(0);
-//            callbackContext.success();
-//
-//        } else if (action.equals(SETTINGS)) {
-//
-//            Intent intent = new Intent(Settings.ACTION_BLUETOOTH_SETTINGS);
-//            cordova.getActivity().startActivity(intent);
-//            callbackContext.success();
-//
-//        } else if (action.equals(ENABLE)) {
-//
-//            enableBluetoothCallback = callbackContext;
-//            Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-//            cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
-//
-//        } else if (action.equals(DISCOVER_UNPAIRED)) {
-//
-//            if (hasBluetoothPermissions()) {
-//                discoverUnpairedDevices(callbackContext);
-//            } else {
-//                permissionCallback = callbackContext;
-//                requestPermissions();
-//            }
-//
-//        } else if (action.equals(SET_DEVICE_DISCOVERED_LISTENER)) {
-//
-//            this.deviceDiscoveredCallback = callbackContext;
-//
-//        } else if (action.equals(CLEAR_DEVICE_DISCOVERED_LISTENER)) {
-//
-//            this.deviceDiscoveredCallback = null;
-//
-//        } else if (action.equals(SET_NAME)) {
-//
-//            String newName = args.getString(0);
-//            bluetoothAdapter.setName(newName);
-//            callbackContext.success();
-//
-//        } else if (action.equals(SET_DISCOVERABLE)) {
-//
-//            int discoverableDuration = args.getInt(0);
-//            Intent discoverIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
-//            discoverIntent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, discoverableDuration);
-//            cordova.getActivity().startActivity(discoverIntent);
-//
-//        } else {
-//            validAction = false;
-//
-//        }
-//
-//        return validAction;
-//    }
-//
-//    private boolean hasBluetoothPermissions() {
-//        if (Build.VERSION.SDK_INT >= 31) { // for android 12 check for Nearby devices permission
-//            return cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT);
-//        } else if (Build.VERSION.SDK_INT == 29 || Build.VERSION.SDK_INT == 30) {
-//            return cordova.hasPermission(ACCESS_FINE_LOCATION);
-//        } else {
-//            return cordova.hasPermission(ACCESS_COARSE_LOCATION);
-//        }
-//    }
-//
-//    private void requestPermissions() {
-//        //Android 12 (API 31) and higher
-//        // Users MUST accept BLUETOOTH_SCAN and BLUETOOTH_CONNECT [nearby devices]
-//        // Android 10 (API 29) up to Android 11 (API 30)
-//        // Users MUST accept ACCESS_FINE_LOCATION
-//        // Users may accept or reject ACCESS_BACKGROUND_LOCATION
-//        // Android 9 (API 28) and lower
-//        // Users MUST accept ACCESS_COARSE_LOCATION
-//
-//        if (Build.VERSION.SDK_INT >= 31) {
-//            cordova.requestPermissions(this, CHECK_PERMISSIONS_REQ_CODE, new String[]{BLUETOOTH_SCAN, BLUETOOTH_CONNECT});
-//        } else if (Build.VERSION.SDK_INT == 29 || Build.VERSION.SDK_INT == 30) {
-//            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, ACCESS_FINE_LOCATION);
-//        } else {
-//            cordova.requestPermission(this, CHECK_PERMISSIONS_REQ_CODE, ACCESS_COARSE_LOCATION);
-//        }
-//
-//    }
-//
-//    @Override
-//    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-//
-//        if (requestCode == REQUEST_ENABLE_BLUETOOTH) {
-//
-//            if (resultCode == Activity.RESULT_OK) {
-//                Log.d(TAG, "User enabled Bluetooth");
-//                if (enableBluetoothCallback != null) {
-//                    enableBluetoothCallback.success();
-//                }
-//            } else {
-//                Log.d(TAG, "User did *NOT* enable Bluetooth");
-//                if (enableBluetoothCallback != null) {
-//                    enableBluetoothCallback.error("User did not enable Bluetooth");
-//                }
-//            }
-//
-//            enableBluetoothCallback = null;
-//        }
-//    }
-//
-//    @Override
-//    public void onDestroy() {
-//        super.onDestroy();
-//        if (bluetoothSerialService != null) {
-//            bluetoothSerialService.stop();
-//        }
-//    }
-//
-//    private void listBondedDevices(CallbackContext callbackContext) throws JSONException {
-//        JSONArray deviceList = new JSONArray();
-//        Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
-//
-//        for (BluetoothDevice device : bondedDevices) {
-//            deviceList.put(deviceToJSON(device));
-//        }
-//        callbackContext.success(deviceList);
-//    }
-//
-//    private void discoverUnpairedDevices(final CallbackContext callbackContext) throws JSONException {
-//
-//        final CallbackContext ddc = deviceDiscoveredCallback;
-//
-//        final BroadcastReceiver discoverReceiver = new BroadcastReceiver() {
-//
-//            private JSONArray unpairedDevices = new JSONArray();
-//
-//            public void onReceive(Context context, Intent intent) {
-//                String action = intent.getAction();
-//                Log.d("AB", "onReceive STRIMG " + action);
-//                if (BluetoothDevice.ACTION_FOUND.equals(action)) {
-//                    BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-//                   // Log.d("AB", "Device DISCOVERED " + device.getName());
-//                    try {
-//                        JSONObject o = deviceToJSON(device);
-//                        unpairedDevices.put(o);
-//                        if (ddc != null) {
-//                            PluginResult res = new PluginResult(PluginResult.Status.OK, o);
-//                            res.setKeepCallback(true);
-//                            ddc.sendPluginResult(res);
-//                        }
-//                    } catch (JSONException e) {
-//                        // This shouldn't happen, Log and ignore
-//                        Log.e(TAG, "Problem converting device to JSON", e);
-//                    }
-//                }
-////                else if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
-////                    if(intent !=null) {
-////                        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-////                        if(device!=null) {
-////                            Log.d("AB", "Device CONNECTED ACL  " + device.getName());
-////                        }
-////                    }
-////                }
-////                else if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
-////
-////                    if(intent !=null) {
-////                        BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-////                        if(device!=null) {
-////                            Log.d("AB", "Device DISSSSSS CONNECTED ACL  " + device.getName());
-////                        }
-////                    }
-////                }
-//                else if (BluetoothAdapter.ACTION_DISCOVERY_FINISHED.equals(action)) {
-//                    callbackContext.success(unpairedDevices);
-//                    cordova.getActivity().unregisterReceiver(this);
-//                }
-//            }
-//        };
-//
-//
-//        Activity activity = cordova.getActivity();
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_FOUND));
-//        activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED));
-//        //activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_CONNECTED));
-//        //activity.registerReceiver(discoverReceiver, new IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED));
-//        bluetoothAdapter.startDiscovery();
-//    }
-//
-//    private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
-//        JSONObject json = new JSONObject();
-//        json.put("name", device.getName());
-//        json.put("address", device.getAddress());
-//        json.put("id", device.getAddress());
-//        if (device.getBluetoothClass() != null) {
-//            json.put("class", device.getBluetoothClass().getDeviceClass());
-//        }
-//        return json;
-//    }
-//
-//    private void connect(final CordovaArgs args, final boolean secure, final CallbackContext callbackContext) throws JSONException {
-//
-//        if (Build.VERSION.SDK_INT >= 31) { // (API 31) Build.VERSION_CODE.S
-//            if(!hasBluetoothPermissions()) {
-//                return;
-//            }
-//        }
-//
-//        String macAddress = args.getString(0);
-//        BluetoothDevice devicePassedToConnect = bluetoothAdapter.getRemoteDevice(macAddress);
-//        Log.d("AB", "---Bluetooth Service initiating to connect device---- ");
-//
-//        if(bluetoothSerialService != null){
-//            BluetoothDevice connectedbluetoothDevice = bluetoothSerialService.getConnectedDevice();
-//            Log.d("AB", "---Bluetooth Service initiating to connect NEW device " + macAddress + " name " + devicePassedToConnect.getName() +  " bluetoothSerialService: " + bluetoothSerialService.getState());
-//
-//            if (connectedbluetoothDevice != null) {
-//                Log.d("AB", "---Bluetooth Service Already Running for Device:" + connectedbluetoothDevice.getName()
-//                    + " bluetoothSerialService.getState()" + bluetoothSerialService.getState());
-//            }
-//
-//            if(connectedbluetoothDevice != null && !connectedbluetoothDevice.getAddress().equalsIgnoreCase(macAddress)) {
-//                if ((bluetoothSerialService.getState() != BluetoothSerialService.STATE_NONE /*BluetoothSerialService.STATE_CONNECTED*/)) {
-//                    Log.d("AB", "---Bluetooth Service Already connecting for a different device, so close that");
-//
-//                    mHandler.removeMessages(0);
-//
-//                        mHandler.postDelayed(() -> {
-//                            try {
-//                                BluetoothSerial.this.connect(args, secure, callbackContext);
-//                            } catch (JSONException e) {
-//                                e.printStackTrace();
-//                            }
-//                        }, 500);
-//
-//                    return;
-////                   bluetoothSerialService.stop();
-////                   bluetoothSerialService = new BluetoothSerialService(mHandler);
-//                    // this requires a bit of time... before starting a new service instance the old one needs to be cleared prperly
-//
-////                try {
-////                    //set time in mili
-////                    Thread.sleep(3000);
-////
-////                }catch (Exception e){
-////                    e.printStackTrace();
-////                }
-//                } else {
-//                    bluetoothSerialService.stop();
-//                    bluetoothSerialService = new BluetoothSerialService(mHandler);
-//                }
-//            }
-//        }
-//
-//        if (devicePassedToConnect != null) {
-//            connectCallback = callbackContext;
-//            Log.d("AB", "Calling connect and start service for device " + devicePassedToConnect.getName() + " bluetoothSerialService: " + bluetoothSerialService);
-//            bluetoothSerialService.start(devicePassedToConnect);
-//            bluetoothSerialService.connect(devicePassedToConnect, secure);
-//            buffer.setLength(0);
-//
-//            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-//            result.setKeepCallback(true);
-//            callbackContext.sendPluginResult(result);
-//
-//        } else {
-//            callbackContext.error("Could not connect to " + macAddress);
-//        }
-//    }
-//
-//    // The Handler that gets information back from the BluetoothSerialService
-//    // Original code used handler for the because it was talking to the UI.
-//    // Consider replacing with normal callbacks
-//    private final Handler mHandler = new Handler() {
-//
-//        public void handleMessage(Message msg) {
-//            switch (msg.what) {
-//                case MESSAGE_READ:
-//                    String bundle = msg.obj.toString();
-//                    Log.d(TAG, bundle);
-//
-//                    if (dataAvailableCallback != null) {
-//                        sendDataToSubscriber(bundle);
-//                    }
-//
-//                    break;
-//                case MESSAGE_READ_RAW:
-//                    if (rawDataAvailableCallback != null) {
-//                        byte[] bytes = (byte[]) msg.obj;
-//                        sendRawDataToSubscriber(bytes);
-//                    }
-//                    break;
-//                case MESSAGE_STATE_CHANGE:
-//
-//                    if(D) Log.i(TAG, "MESSAGE_STATE_CHANGE: " + msg.arg1);
-//                    switch (msg.arg1) {
-//                        case BluetoothSerialService.STATE_CONNECTED:
-//                            Log.i(TAG, "BluetoothSerialService.STATE_CONNECTED");
-////                            notifyConnectionSuccess("CONNECTED");
-//                            notifyConnectionSuccess();
-//                            break;
-//                        case BluetoothSerialService.STATE_CONNECTING:
-//                            Log.i(TAG, "BluetoothSerialService.STATE_CONNECTING");
-//                            break;
-//                        case BluetoothSerialService.STATE_LISTEN:
-//                            Log.i(TAG, "BluetoothSerialService.STATE_LISTEN");
-//                            break;
-//                        case BluetoothSerialService.STATE_NONE:
-//                            Log.i(TAG, "BluetoothSerialService.STATE_NONE");
-//                            break;
-//                    }
-//                    break;
-//                case MESSAGE_WRITE:
-//                    byte[] writeBuf = (byte[]) msg.obj;
-//                    String writeMessage = new String(writeBuf);
-//                    Log.i(TAG, "Wrote: " + writeMessage);
-//                    break;
-//                case MESSAGE_DEVICE_NAME:
-//                    Log.i(TAG, msg.getData().getString(DEVICE_NAME));
-//                    break;
-//                case MESSAGE_TOAST:
-//                    String message = msg.getData().getString(TOAST);
-//                    notifyConnectionLost(message);
-//                    break;
-//            }
-//        }
-//    };
-//
-//    private void notifyConnectionLost(String error) {
-//        if (connectCallback != null) {
-//            connectCallback.error(error);
-//            connectCallback = null;
-//        }
-//    }
-//
-//    private void notifyConnectionSuccess() {
-//        if (connectCallback != null) {
-//
-////            PluginResult result = new PluginResult(PluginResult.Status.OK); //nehal  if paired -> PAIRED; OK -> connected
-////            result.setKeepCallback(true);
-////            connectCallback.sendPluginResult(result);
-//
-//            BluetoothDevice connectedDevice;
-//            JSONObject o = null;
-//            PluginResult res;
-//            //nehal sending device object to which connection has been made
-//            if (bluetoothSerialService != null) {
-//                connectedDevice = bluetoothSerialService.getConnectedDevice();
-//            try {
-//                o = deviceToJSON(connectedDevice);
-//                res = new PluginResult(PluginResult.Status.OK, o);
-//            } catch (JSONException e) {
-//                e.printStackTrace();
-//                res = new PluginResult(PluginResult.Status.OK);
-//            }
-//
-//            } else {
-//            res = new PluginResult(PluginResult.Status.OK);
-//            }
-//
-//             res.setKeepCallback(true);
-//             connectCallback.sendPluginResult(res);
-//
-//        }
-//    }
-//
-////    private void notifyConnectionSuccess(String data) {
-////        if (connectCallback != null) {
-////            PluginResult result = new PluginResult(PluginResult.Status.OK, data); //nehal  if paired -> PAIRED; OK -> connected
-////            result.setKeepCallback(true);
-////            connectCallback.sendPluginResult(result);
-////        }
-////    }
-//
-//    private void sendRawDataToSubscriber(byte[] data) {
-//        if (data != null && data.length > 0) {
-//            PluginResult result = new PluginResult(PluginResult.Status.OK, data);
-//            result.setKeepCallback(true);
-//            rawDataAvailableCallback.sendPluginResult(result);
-//        }
-//    }
-//
-//    private void sendDataToSubscriber(String data) {
-//        if (data != null) {
-//            PluginResult result = new PluginResult(PluginResult.Status.OK, data);
-//            result.setKeepCallback(true);
-//            dataAvailableCallback.sendPluginResult(result);
-//        }
-//    }
-//
-//    private int available() {
-//        return buffer.length();
-//    }
-//
-//    private String read() {
-//        int length = buffer.length();
-//        String data = buffer.substring(0, length);
-//        buffer.delete(0, length);
-//        return data;
-//    }
-//
-//    private String readUntil(String c) {
-//        String data = "";
-//        int index = buffer.indexOf(c, 0);
-//        if (index > -1) {
-//            data = buffer.substring(0, index + c.length());
-//            buffer.delete(0, index + c.length());
-//        }
-//        return data;
-//    }
-//
-//
-//    private  boolean verifyPermissions(int[] grantResults) {
-//        // At least one result must be checked.
-//        if(grantResults.length < 1){
-//            return false;
-//        }
-//        // Verify that each required permission has been granted, otherwise return false.
-//        for (int result : grantResults) {
-//            if (result != PackageManager.PERMISSION_GRANTED) {
-//                return false;
-//            }
-//        }
-//        return true;
-//    }
-//
-//    @Override
-//    public void onRequestPermissionResult(int requestCode, String[] permissions,
-//                                          int[] grantResults) throws JSONException {
-//
-//        if (requestCode == CHECK_PERMISSIONS_REQ_CODE) {
-//            if (verifyPermissions(grantResults)) {
-//                discoverUnpairedDevices(permissionCallback);
-//                this.permissionCallback = null;
-//            } else {
-//                // permissions not granted, disable functionality or show message
-//                if (Build.VERSION.SDK_INT >= 31) {
-//                    Log.d(TAG, "User did not grant Nearby devices permission");
-//                } else {
-//                    Log.d(TAG, "User did not grant location permission");
-//                }
-//            }
-//        } else {
-//            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-//        }
-//
-//    }
-//
-//    public void registerStateChangeReceiver(Context context) {
-//        if(actionFoundReceiver == null) {
-//            //nehal
-//            IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-//            filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
-//            filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
-//            actionFoundReceiver = new BluetoothBroadcastReceiver();
-//            context.registerReceiver(actionFoundReceiver, filter);
-//        }
-//    }
-//
-//    /**
-//     * Broadcast receiver listening to bluetooth connection and pairing actions
-//     */
-//    private class BluetoothBroadcastReceiver extends BroadcastReceiver {
-//
-//        @Override
-//        public void onReceive(Context context, Intent intent) {
-//            try {
-//                String action = intent.getAction();
-//                Bundle bundle = intent.getExtras();
-//
-//                /* Logging of actions received for debugging purpose */
-//                if (BluetoothDevice.ACTION_FOUND.equals(action) && bundle != null) {
-//                    for (String key : bundle.keySet()) {
-//                        Log.d(TAG, String.format("======%s :  %s--%s", action, key,
-//                            bundle.get(key) != null ? Objects.requireNonNull(bundle.get(key)).toString() : "null"));
-//                    }
-//                }
-//
-//                if (action == null) return;
-//
-//                switch (action) {
-//                    case BluetoothDevice.ACTION_BOND_STATE_CHANGED:
-//                        Log.d(TAG, "ACTION_BOND_STATE_CHANGED");
-//                        onPairingStateChanged(Objects.requireNonNull(bundle), intent);
-//                        break;
-//
-//                    case BluetoothDevice.ACTION_FOUND:
-//                        break;
-//
-//                    case BluetoothDevice.ACTION_ACL_CONNECTED:
-//                        if(intent !=null) {
-//                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-//                            if(device!=null) {
-//                                Log.d("AB", "Device CONNECTED ACL  " + device.getName());
-//                            }
-//                        }
-//                        break;
-//                    case BluetoothDevice.ACTION_ACL_DISCONNECTED:
-//                        //NEHAL FINDINGS :
-//                        // Even if the device is transmitting the readings and is ON, then also this event gets notfication at a very early time
-//                        // when we turn on a device, state is not changing from isConnected to CONNECTING..
-//                        if(intent !=null) {
-//                            BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-//                            if(device!=null) {
-//                                Log.d("AB", "Device Disconnected ACL  " + device.getName());
-//                                Log.d("AB", "BT service instance " + bluetoothSerialService);
-//                                 bluetoothSerialService.setStateNone();
-//                            }
-//                        }
-//                    default:
-//                        break;
-//                }
-//            } catch (Exception e) {
-//                Log.d(TAG,
-//                    "Exception onReceive in Device paired with the sensor" + e);
-//            }
-//        }
-//
-//        BluetoothDevice mBluetoothDevice;
-//        /**
-//         * Handling of pairing/bonding state changes action
-//         * BOND_NONE       --> BOND_BONDING: Pairing started
-//         * BOND_BONDING    --> BOND_NONE   : Pairing error, as pairing was not completed to BOND_BONDED status
-//         * BOND_BONDING    --> BOND_BONDED : Pairing completed
-//         *
-//         * @param bundle broadcast bundle
-//         **/
-//        private void onPairingStateChanged(Bundle bundle, Intent intent) {
-//            if(mBluetoothDevice==null){
-//                mBluetoothDevice = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-//            }
-//            int newBondState = bundle.getInt(BluetoothDevice.EXTRA_BOND_STATE);
-//            int previousBondState = bundle.getInt(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE);
-//            Log.d(TAG, "Previous bond state: " + previousBondState + " ---> New bond state: " + newBondState);
-//            String deviceInfoLog =  " | " + mBluetoothDevice.getName() + "| MACId: " + mBluetoothDevice.getAddress();
-//            switch (newBondState) {
-//                case BluetoothDevice.BOND_NONE:
-//                    /* Possible pairing failed case as Pairing state changed from BOND_BONDING to BOND_NONE */
-//                    if (previousBondState == BluetoothDevice.BOND_BONDING) {
-//                        Log.d(TAG, "********** Possible pairing failed as pairing state changed from BOND_BONDING to BOND_NONE **********");
-//                       // cancelDeviceDiscovery();
-//                        //  mListener.onPairingError(FailureReason.FAILED);
-//                    }
-//                    break;
-//
-//                case BluetoothDevice.BOND_BONDING:
-//                    /* Pairing started for device, start a timeout handler */
-//                    Log.d(TAG, "********** Pairing Initiated with Device :" + deviceInfoLog + " **********");
-//                    // mListener.onPairingStarted();
-//                    break;
-//
-//                case BluetoothDevice.BOND_BONDED:
-//                    Log.d(TAG, "********** Device paired successfully :" + deviceInfoLog + "  **********");
-//                    //  cancelDeviceDiscovery();
-////                    onPairingCompleted();
-//                   // notifyConnectionSuccess("PAIRED");
-//                    break;
-//                default:
-//                    break;
-//            }
-//        }
-//
-//    }
-//}

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -132,15 +132,13 @@ public class BluetoothSerialService {
             // this is specifically for the A&D devices for the SPP listener mode
             device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
         ) {
-          //   startBluetoothSPPListener(device);
-
             resetConnectedBTDevice();
 
             if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
                 Log.d(TAG, "## SPP thread is alive!!!");
                 sppAcceptThread.resetDevice(device);
             } else {
-                Log.d(TAG, "## NEW SPP thread !!!");
+                Log.d(TAG, "## New SPP thread !!!");
                 sppAcceptThread = new SPPAcceptThread(device);
                 sppAcceptThread.start();
             }
@@ -176,10 +174,6 @@ public class BluetoothSerialService {
             mmServerSocket = null;
             this.device = device;
             Log.d(TAG, "New SPP Accept thread for device " + device.getName());
-//            try {
-//                mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-//            } catch (IOException e) { }
-            // mmServerSocket = tmp;
         }
 
         public void run() {
@@ -190,18 +184,18 @@ public class BluetoothSerialService {
                 mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
 
 
-            while (true/* mState != STATE_CONNECTED*/) {
-                try {
-                    Log.d(TAG, "----- > SPP accept thread ---> ");
+                while (true/* mState != STATE_CONNECTED*/) {
+                    try {
+                        Log.d(TAG, "----- > SPP accept thread ---> ");
 
-                    socket = mmServerSocket.accept();
-                } catch (IOException e) {
-                    Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
-                }
+                        socket = mmServerSocket.accept();
+                    } catch (IOException e) {
+                        Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
+                    }
 
-                // If a connection was accepted
-                if (socket != null) {
-                    //synchronized (BluetoothSerialService.this) {
+                    // If a connection was accepted
+                    if (socket != null) {
+                        //synchronized (BluetoothSerialService.this) {
                         // Do work to manage the connection (in a separate thread)
                         try {
                             Log.d(TAG, " -- > SPP thread --> connection accepted -- > ");
@@ -224,9 +218,6 @@ public class BluetoothSerialService {
                         } catch (Exception e) {
                             Log.d(TAG, "Bluetooth Socket Error", e);
                         }
-//                        finally {
-//                            closeBluetoothConnection();
-//                        }
                         try {
                             if(mmServerSocket!=null) {
                                 mmServerSocket.close();
@@ -236,8 +227,8 @@ public class BluetoothSerialService {
                         }
                         break;
                     }
-               // }
-            }
+
+                }
 
 
             }
@@ -255,88 +246,6 @@ public class BluetoothSerialService {
             } catch (IOException e) { }
         }
     }
-
-    private void startBluetoothSPPListener(BluetoothDevice device){
-        //start the bluetooth listener as its own thread
-        //this listener checks for all incoming bluetooth connections and invokes the proper class object associated with that device
-
-
-        Thread adt=new Thread(new Runnable(){
-
-
-
-            @Override
-            public void run() {
-                try{
-                    bluetoothDevice = device;
-                    Log.d(TAG, "Starting listening mode");
-                    BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-                    while(true) {
-                        BluetoothServerSocket bluetoothSocket=adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-                        // final BluetoothSocket bs=bluetoothSocket.accept();
-                        BluetoothSocket bs;
-                        try {
-                            bs = bluetoothSocket.accept();
-                        }catch (IOException ex){
-                           // Log.d(TAG,"SPP Listener Run: bluetoothSocket" + ex.getMessage());
-                         //   Thread.sleep(1000);
-                            break;
-                          //  continue;
-                        }
-                        if (bs == null) {
-                            try {
-                                closeConnection();
-                            } catch(Exception e) {
-                                Log.d(TAG,"CLOSE", e);
-                            }
-                        }
-                        if(bluetoothSocket!=null)
-                            bluetoothSocket.close();
-
-                        Log.d(TAG, "Incoming bluetooth connection");
-                        Thread bst = new Thread(new Runnable(){
-
-                            @Override
-                            public void run() {
-                                try{
-                                    BluetoothDevice btDevice =   connectedBlueToothDevice;//  bluetoothDevice; //device;
-                                    String deviceType = "";
-                                    try{
-                                        String deviceAddr = btDevice.getAddress();
-                                        //found connected device profile, get results
-                                        Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
-                                        if (btDevice.getName().contains("UA-767")) {
-                                            deviceType = "bloodpressure";
-                                        } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
-                                            deviceType = "scale";
-                                        }
-                                        onConnection(bs);
-                                        readData(bs, deviceType);
-                                    }
-                                    catch(Exception e){
-                                        Log.d(TAG,"Error finding bluetooth device" + e);
-                                    }
-                                }
-                                catch(Exception e){
-                                    Log.d(TAG,"Bluetooth Socket Error", e);
-                                }
-                            }
-
-                        });
-                        bst.start();
-                    }
-                }
-                catch(Exception e){
-                    Log.d(TAG,"Bluetooth Listener Error",e);
-                }
-            }
-
-        });
-        adt.start();
-    }
-
-
-
 
     /**
      * Start the ConnectThread to initiate a connection to a remote device.
@@ -404,7 +313,6 @@ public class BluetoothSerialService {
             msg.setData(bundle);
             mHandler.sendMessage(msg);
 
-            //setState(STATE_CONNECTED);
         }
         setState(STATE_CONNECTED);
 
@@ -613,9 +521,7 @@ public class BluetoothSerialService {
                 mmSocket = tmp;
             } else {
                 try {
-                    tmp = /*mmDevice*/device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-//                    mAdapter.cancelDiscovery();
-//                    tmp.connect();
+                    tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
                 } catch (IOException e) {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
@@ -650,7 +556,7 @@ public class BluetoothSerialService {
                     try {
                         Log.i(TAG, "Trying fallback...");
                         mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
-                   //    mmSocket =(BluetoothSocket)  mmDevice.getClass().getMethod("createInsecureRfcommSocketToServiceRecord", new Class[] { UUID.class }).invoke(mmDevice, UUID_SPP);
+
                         mmSocket.connect();
                         Log.i(TAG, "Connected");
                         connectedBlueToothDevice = mmSocket.getRemoteDevice();
@@ -693,23 +599,18 @@ public class BluetoothSerialService {
                                 mmSocket.close();
                             }
 
-                            } catch (IOException e3) {
-                                Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-                            }
-                            // closeBluetoothConnection();
-                            // Send the name of the connected device back to the UI Activity
-                            // Send a failure message back to the Activity
-                            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-                            Bundle bundle = new Bundle();
-                            bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
-                            msg.setData(bundle);
-                            mHandler.sendMessage(msg);
+                        } catch (IOException e3) {
+                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+                        }
 
-//                        } catch (IOException e3) {
-//                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-//                        }
+                        // Send the name of the connected device back to the UI Activity
+                        // Send a failure message back to the Activity
+                        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+                        Bundle bundle = new Bundle();
+                        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
+                        msg.setData(bundle);
+                        mHandler.sendMessage(msg);
 
-                        //return;
                     }
                 }
 
@@ -734,7 +635,7 @@ public class BluetoothSerialService {
 
     private void connectToDevice(BluetoothSocket socket) throws IOException {
         mmSocket = socket;
-        connectedBlueToothDevice = socket.getRemoteDevice();// bluetoothDevice = socket.getRemoteDevice();
+        connectedBlueToothDevice = socket.getRemoteDevice();
         Log.d(TAG, "bluetoothDevice CONNECTED OR NOT: " + socket.isConnected());
         in = socket.getInputStream();
         out = socket.getOutputStream();
@@ -781,7 +682,7 @@ public class BluetoothSerialService {
         return (val << shift);
     }
 
-    private /*void*/ int readPatientPacket() throws IOException{
+    private int readPatientPacket() throws IOException{
         // Check the packet length...
         plen = in.read() + shift(in.read(),8) + shift(in.read(),16) + shift(in.read(),24);
         Log.d(TAG,"packet len: " + plen);
@@ -863,13 +764,12 @@ public class BluetoothSerialService {
         if (socket!=null) {
             in = socket.getInputStream();
             out = socket.getOutputStream();
-            restartBluetoothTimeout(socket);
         }
     }
 
     private void readData(BluetoothSocket socket, String deviceType) throws IOException{
         connectToDevice(socket);
-        setState(STATE_CONNECTED); //nehal new
+        setState(STATE_CONNECTED);
         readPatientInfoPacket();
         int devType = readPatientPacket();
         Log.d(TAG, "## device type " + deviceType);
@@ -878,51 +778,18 @@ public class BluetoothSerialService {
             BluetoothDevice connectedBTDevice = socket.getRemoteDevice(); //gives the currently connected device
             if(connectedBTDevice!=null) {
                 Log.d(TAG, "## connected BT device " + connectedBTDevice.getName());
-                //Log.d("AB", "## staleinstace BT device " + bluetoothDevice.getName());
                 connectedBlueToothDevice = connectedBTDevice;
             }
         }
         Log.d(TAG, " Connected device type " + connectedBlueToothDevice.getName());
-        if(devType == 766 || connectedBlueToothDevice.getName().contains("UA-767") /*|| deviceType.equals("bloodpressure")*/) { //device keeps on getting changed, recheck device frm data obtained
+        if(devType == 766 || connectedBlueToothDevice.getName().contains("UA-767") ) { //device keeps on getting changed, recheck device frm data obtained
             onBPDataPacket();
         } else {
             onScaleDataPacket();
         }
 
-//        if (deviceType == "bloodpressure") { //string comparison
-//            onBPDataPacket();
-//        } else {
-//            onScaleDataPacket();
-//        }
-
         sendAcknowledgement();
         closeConnection();
-    }
-
-    //bluetooth socket timeout functions
-    protected void startBluetoothTimeout(BluetoothSocket socket){
-//        bluetooth_timer=new Timer();
-//        bluetooth_timer.schedule(new TimerTask() {
-//            @Override
-//            public void run() {
-//                //shut down the bluetooth socket
-//                Log.d(TAG,"bluetooth socket timeout...");
-//                try {
-//                    socket.close();
-//                } catch(Exception e) {}
-//            }
-//        }, bluetooth_timeout);
-    }
-
-    protected void cancelBluetoothTimeout(){
-//        try{
-//            bluetooth_timer.cancel();
-//        }
-//        catch(Exception e){}
-    }
-    protected void restartBluetoothTimeout(BluetoothSocket socket){
-        cancelBluetoothTimeout();
-        startBluetoothTimeout(socket);
     }
 
     /**
@@ -1096,7 +963,8 @@ public class BluetoothSerialService {
     public synchronized BluetoothDevice getConnectedDevice() {
         if (connectedBlueToothDevice!=null) {
             return connectedBlueToothDevice;
-        } else {
+        }
+        else {
             return bluetoothDevice;
         }
     }
@@ -1106,7 +974,6 @@ public class BluetoothSerialService {
         try{if(in!=null) {in.close();}}catch(Exception e){e.printStackTrace();}
         try{if(out!=null) {out.close();}}catch(Exception e){e.printStackTrace();}
         try{if(mmSocket!=null) {mmSocket.close();}}catch(Exception e){e.printStackTrace();}
-        cancelBluetoothTimeout();
         setState(STATE_NONE);
     }
 }

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -6,7 +6,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -17,10 +16,6 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -81,7 +76,7 @@ public class BluetoothSerialService {
 
     public int getDataPacketLength(){return plen;}
 
-   // private BluetoothBroadcastReceiver actionFoundReceiver;
+
     /**
      * Constructor. Prepares a new BluetoothSerial session.
      * @param handler  A Handler to send messages back to the UI Activity
@@ -90,21 +85,7 @@ public class BluetoothSerialService {
         mAdapter = BluetoothAdapter.getDefaultAdapter();
         mState = STATE_NONE;
         mHandler = handler;
-
-
     }
-
-//    public void registerStateChangeReceiver(Context context) {
-//
-//
-//        //nehal
-//        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-//        // filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
-//        // filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-//        // filter.addAction(BluetoothDevice.ACTION_FOUND);
-//        actionFoundReceiver = new BluetoothBroadcastReceiver();
-//        context.registerReceiver(actionFoundReceiver, filter);
-//    }
 
     /**
      * Set the current state of the chat connection
@@ -123,49 +104,159 @@ public class BluetoothSerialService {
     public synchronized int getState() {
         return mState;
     }
+    SPPAcceptThread sppAcceptThread;
 
     /**
      * Start the chat service. Specifically start AcceptThread to begin a
      * session in listening (server) mode. Called by the Activity onResume() */
     public synchronized void start(BluetoothDevice device) {
         if (D) Log.d(TAG, "start");
-//        if (
-//            // this is specifically for the A&D devices for the SPP listener mode
-//                device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-//        ) {
-//            startBluetoothSPPListener(device);
-//        } else {
-            // Cancel any thread attempting to make a connection
-            if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+        // Cancel any thread attempting to make a connection
+        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
 
-            // Cancel any thread currently running a connection
-            if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+        // Cancel any thread currently running a connection
+        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
 
-            setState(STATE_NONE);
+        setState(STATE_NONE);
 
         if (
             // this is specifically for the A&D devices for the SPP listener mode
             device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
         ) {
-            startBluetoothSPPListener(device);
+            // startBluetoothSPPListener(device);
+            if(sppAcceptThread!=null) {
+                Log.d("AB", "SPP Accept Thread OLD CANCELEEDED");
+                sppAcceptThread.cancel();
+                sppAcceptThread = null;
+            }
+            sppAcceptThread = new SPPAcceptThread();
+            sppAcceptThread.start();
+            Log.d("AB", "New SPP Thread created");
         }
 
- //       }
+
+//        if (D) Log.d(TAG, "start");
+//        if (
+//            // this is specifically for the A&D devices for the SPP listener mode
+//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+//        ) {
+//           // startBluetoothSPPListener(device);
+//            if(sppAcceptThread!=null) {
+//                Log.d("AB", "SPP Accept Thread OLD CANCELEEDED");
+//                sppAcceptThread.cancel();
+//                sppAcceptThread = null;
+//            }
+//             sppAcceptThread = new SPPAcceptThread();
+//             sppAcceptThread.start();
+//             Log.d("AB", "New SPP Thread created");
+//        } else {
+//            // Cancel any thread attempting to make a connection
+//            if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+//
+//            // Cancel any thread currently running a connection
+//            if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+//
+//            setState(STATE_NONE);
+//        }
+    }
+
+    public void setStateNone() {
+        setState(STATE_NONE);
+    }
+
+    private class SPPAcceptThread extends Thread {
+        private final BluetoothServerSocket mmServerSocket;
+        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+
+        public SPPAcceptThread() {
+            // Use a temporary object that is later assigned to mmServerSocket,
+            // because mmServerSocket is final
+            BluetoothServerSocket tmp = null;
+            try {
+                // MY_UUID is the app's UUID string, also used by the client code
+                tmp = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
+            } catch (IOException e) { }
+            mmServerSocket = tmp;
+        }
+
+        public void run() {
+            BluetoothSocket socket = null;
+            // Keep listening until exception occurs or a socket is returned
+            while (true) {
+                try {
+                    socket = mmServerSocket.accept();
+                } catch (IOException e) {
+                    break;
+                }
+                // If a connection was accepted
+                if (socket != null) {
+                    // Do work to manage the connection (in a separate thread)
+                    try{
+                        BluetoothDevice btDevice =   bluetoothDevice; //device;
+                        String deviceType = "";
+                        try{
+                            String deviceAddr = btDevice.getAddress();
+                            //found connected device profile, get results
+                            Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
+                            if (btDevice.getName().contains("UA-767")) {
+                                deviceType = "bloodpressure";
+                            } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
+                                deviceType = "scale";
+                            }
+                            onConnection(socket);
+                            readData(socket, deviceType);
+                        }
+                        catch(Exception e){
+                            Log.d(TAG,"Error finding bluetooth device" + e);
+                        }
+                    }
+                    catch(Exception e){
+                        Log.d(TAG,"Bluetooth Socket Error", e);
+                    }
+                    try {
+                        mmServerSocket.close();
+                    } catch (IOException exception) {
+                        exception.printStackTrace();
+                    }
+                    break;
+                }
+            }
+        }
+
+        /** Will cancel the listening socket, and cause the thread to finish */
+        public void cancel() {
+            try {
+                mmServerSocket.close();
+            } catch (IOException e) { }
+        }
     }
 
     private void startBluetoothSPPListener(BluetoothDevice device){
         //start the bluetooth listener as its own thread
         //this listener checks for all incoming bluetooth connections and invokes the proper class object associated with that device
+
+
         Thread adt=new Thread(new Runnable(){
+
+
 
             @Override
             public void run() {
                 try{
+                    bluetoothDevice = device; //new neahl
                     Log.d(TAG, "Starting listening mode");
                     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
                     while(true) {
                         BluetoothServerSocket bluetoothSocket=adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-                        final BluetoothSocket bs=bluetoothSocket.accept();
+                        // final BluetoothSocket bs=bluetoothSocket.accept();
+                        BluetoothSocket bs;
+                        try {
+                            bs = bluetoothSocket.accept();
+                        }catch (IOException ex){
+                            Log.d(TAG,"SPP Listener Run: bluetoothSocket" + ex.getMessage());
+                            Thread.sleep(1000);
+                            continue;
+                        }
                         if (bs == null) {
                             try {
                                 closeConnection();
@@ -173,7 +264,8 @@ public class BluetoothSerialService {
                                 Log.d(TAG,"CLOSE", e);
                             }
                         }
-                        bluetoothSocket.close();
+                        if(bluetoothSocket!=null)
+                            bluetoothSocket.close();
 
                         Log.d(TAG, "Incoming bluetooth connection");
                         Thread bst = new Thread(new Runnable(){
@@ -181,7 +273,7 @@ public class BluetoothSerialService {
                             @Override
                             public void run() {
                                 try{
-                                    BluetoothDevice btDevice = device;
+                                    BluetoothDevice btDevice =   bluetoothDevice; //device;
                                     String deviceType = "";
                                     try{
                                         String deviceAddr = btDevice.getAddress();
@@ -216,6 +308,8 @@ public class BluetoothSerialService {
         });
         adt.start();
     }
+
+
 
     /**
      * Start the ConnectThread to initiate a connection to a remote device.
@@ -266,9 +360,9 @@ public class BluetoothSerialService {
 
         // Start the thread to manage the connection and perform transmissions
         if (
-                !device.getName().contains("UA-767") &&
-                        !device.getName().contains("UC-355") &&
-                        !device.getName().contains("UC-351")
+            !device.getName().contains("UA-767") &&
+                !device.getName().contains("UC-355") &&
+                !device.getName().contains("UC-351")
         ) {
             mConnectedThread = new ConnectedThread(socket, socketType, device);
             mConnectedThread.start();
@@ -283,8 +377,6 @@ public class BluetoothSerialService {
 
         setState(STATE_CONNECTED);
     }
-
-
 
     /**
      * Stop all threads
@@ -311,6 +403,8 @@ public class BluetoothSerialService {
             mInsecureAcceptThread.cancel();
             mInsecureAcceptThread = null;
         }
+
+
         setState(STATE_NONE);
     }
 
@@ -413,7 +507,7 @@ public class BluetoothSerialService {
                             case STATE_CONNECTING:
                                 // Situation normal. Start the connected thread.
                                 connected(socket, socket.getRemoteDevice(),
-                                        mSocketType);
+                                    mSocketType);
                                 break;
                             case STATE_NONE:
                             case STATE_CONNECTED:
@@ -456,24 +550,22 @@ public class BluetoothSerialService {
         public ConnectThread(BluetoothDevice device, boolean secure) {
             mmDevice = device;
             BluetoothSocket tmp = null;
-            if ( //nehal
-                device.getName().contains("UA-767") ||
-                    device.getName().contains("UC-355") ||
-                    device.getName().contains("UC-351")
-            ) {
-                secure = false;
+            mSocketType = secure ? "Secure" : "Insecure";
+            try {
+                if(mmSocket!=null) {
+                    mmSocket.close();
+                }
+
+            } catch (IOException e3) {
+                Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
             }
 
-            mSocketType = secure ? "Secure" : "Insecure";
-
-
-
             // Get a BluetoothSocket for a connection with the given BluetoothDevice
-//            if (
-//                    !device.getName().contains("UA-767") &&
-//                            !device.getName().contains("UC-355") &&
-//                            !device.getName().contains("UC-351")
-//            ) {
+            if (
+                !device.getName().contains("UA-767") &&
+                    !device.getName().contains("UC-355") &&
+                    !device.getName().contains("UC-351")
+            ) {
                 // Get a BluetoothSocket for a connection with the given BluetoothDevice
                 try {
                     if (secure) {
@@ -485,77 +577,107 @@ public class BluetoothSerialService {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
                 mmSocket = tmp;
-
-                mAdapter.cancelDiscovery(); 
-//            } else {
-//                try {
-//                    tmp = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+            } else {
+                try {
+                    tmp = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
 //                    mAdapter.cancelDiscovery();
 //                    tmp.connect();
-//                } catch (IOException e) {
-//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-//                }
-//                mmSocket = tmp;
-//            }
+                } catch (IOException e) {
+                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
+                }
+                mmSocket = tmp;
+            }
         }
 
         public void run() {
             Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
             setName("ConnectThread" + mSocketType);
 
-//            if (
-//                    !mmDevice.getName().contains("UA-767") &&
-//                            !mmDevice.getName().contains("UC-355") &&
-//                            !mmDevice.getName().contains("UC-351")
-//            ) {
+            if (
+                !mmDevice.getName().contains("UA-767") &&
+                    !mmDevice.getName().contains("UC-355") &&
+                    !mmDevice.getName().contains("UC-351")
+            ) {
                 // Always cancel discovery because it will slow down a connection
-          //      mAdapter.cancelDiscovery();
+                mAdapter.cancelDiscovery();
 
                 // Make a connection to the BluetoothSocket
                 try {
                     // This is a blocking call and will only return on a successful connection or an exception
-                    Log.i(TAG,"Connecting to socket...");
+                    Log.i(TAG, "Connecting to socket...");
                     mmSocket.connect();
-                    Log.i(TAG,"Connected");
+                    Log.i(TAG, "Connected");
                 } catch (IOException e) {
                     Log.e(TAG, e.toString());
 
                     // Some 4.1 devices have problems, try an alternative way to connect
                     // See https://github.com/don/BluetoothSerial/issues/89
                     try {
-                        Log.i(TAG,"Trying fallback...");
-                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
+                        Log.i(TAG, "Trying fallback...");
+                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
+                   //    mmSocket =(BluetoothSocket)  mmDevice.getClass().getMethod("createInsecureRfcommSocketToServiceRecord", new Class[] { UUID.class }).invoke(mmDevice, UUID_SPP);
                         mmSocket.connect();
-                        Log.i(TAG,"Connected");
+                        Log.i(TAG, "Connected");
                     } catch (Exception e2) {
                         Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-
-
-                                        try {
-                                            mmSocket.close();
-                                        } catch (IOException e3) {
-                                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-                                        }
-                        if (
-                            !mmDevice.getName().contains("UA-767") &&
-                                !mmDevice.getName().contains("UC-355") &&
-                                !mmDevice.getName().contains("UC-351")
-                        ) {
-                                        connectionFailed();
-
-                                    }
+                        try {
+                            mmSocket.close();
+                        } catch (IOException e3) {
+                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+                        }
+                        connectionFailed();
                         return;
                     }
-               // }
-            }
+                }
+            } else {
+                // for SPP..
+                // Make a connection to the BluetoothSocket
+                try {
+                    // This is a blocking call and will only return on a successful connection or an exception
+                    Log.i(TAG, "Connecting to socket...");
+                    mmSocket.connect();
+                    Log.i(TAG, "Connected");
+                } catch (IOException e) {
+                    Log.e(TAG, e.toString());
 
-            // Reset the ConnectThread because we're done
-            synchronized (BluetoothSerialService.this) {
-                mConnectThread = null;
-            }
+                    // Some 4.1 devices have problems, try an alternative way to connect
+                    // See https://github.com/don/BluetoothSerial/issues/89
+                    try {
+                        Log.i(TAG, "Trying fallback...");
+                           mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
 
-            // Start the connected thread
-            connected(mmSocket, mmDevice, mSocketType);
+
+                        mmSocket.connect();
+                        Log.i(TAG, "Connected");
+                    } catch (Exception e2) {
+                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
+                        try {
+                            mmSocket.close();
+                            closeBluetoothConnection();
+                            // Send the name of the connected device back to the UI Activity
+                            // Send a failure message back to the Activity
+                            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+                            Bundle bundle = new Bundle();
+                            bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
+                            msg.setData(bundle);
+                            mHandler.sendMessage(msg);
+
+                        } catch (IOException e3) {
+                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+                        }
+
+                        return;
+                    }
+                }
+
+                // Reset the ConnectThread because we're done
+                synchronized (BluetoothSerialService.this) {
+                    mConnectThread = null;
+                }
+
+                // Start the connected thread
+                connected(mmSocket, mmDevice, mSocketType);
+            }
         }
         public void cancel() {
             try {
@@ -615,7 +737,7 @@ public class BluetoothSerialService {
         return (val << shift);
     }
 
-    private void readPatientPacket() throws IOException{
+    private /*void*/ int readPatientPacket() throws IOException{
         // Check the packet length...
         plen = in.read() + shift(in.read(),8) + shift(in.read(),16) + shift(in.read(),24);
         Log.d(TAG,"packet len: " + plen);
@@ -673,9 +795,9 @@ public class BluetoothSerialService {
         //get device name and serial number
         String devnameupper = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
         String devserial = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-                "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
+            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
         String devnamelower = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-                "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
+            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
 
         //device battery status
         int batterystatus = in.read();
@@ -686,6 +808,8 @@ public class BluetoothSerialService {
 
         //get device firmware/hardware
         int devfirmwarehardware = in.read();
+
+        return devType;
     }
 
 
@@ -702,12 +826,17 @@ public class BluetoothSerialService {
     private void readData(BluetoothSocket socket, String deviceType) throws IOException{
         connectToDevice(socket);
         readPatientInfoPacket();
-        readPatientPacket();
-        if (deviceType == "bloodpressure") {
-            onBPDataPacket();
-        } else {
+        int devType = readPatientPacket();
+        if(devType == 322) { //device keeps on getting changed, yaha se device bhi pass karna padege
             onScaleDataPacket();
+        } else {
+            onBPDataPacket();
         }
+//        if (deviceType == "bloodpressure") {
+//            onBPDataPacket();
+//        } else {
+//            onScaleDataPacket();
+//        }
 
         sendAcknowledgement();
         closeConnection();
@@ -903,10 +1032,1224 @@ public class BluetoothSerialService {
         closeBluetoothConnection();
     }
 
+    public synchronized BluetoothDevice getConnectedDevice() {
+        return bluetoothDevice;
+    }
+
     protected void closeBluetoothConnection() throws IOException {
+        //try catching NPE for all before closing
         try{in.close();}catch(Exception e){e.printStackTrace();}
         try{out.close();}catch(Exception e){e.printStackTrace();}
         try{mmSocket.close();}catch(Exception e){e.printStackTrace();}
         cancelBluetoothTimeout();
     }
 }
+
+//package com.megster.cordova;
+//
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.io.OutputStream;
+//import java.lang.reflect.InvocationTargetException;
+//import java.util.Date;
+//import java.util.Timer;
+//import java.util.TimerTask;
+//import java.util.UUID;
+//import java.util.Arrays;
+//
+//import android.bluetooth.BluetoothAdapter;
+//import android.bluetooth.BluetoothDevice;
+//import android.bluetooth.BluetoothServerSocket;
+//import android.bluetooth.BluetoothSocket;
+//import android.os.Bundle;
+//import android.os.Handler;
+//import android.os.Message;
+//import android.util.Log;
+//
+//
+///**
+// * This class does all the work for setting up and managing Bluetooth
+// * connections with other devices. It has a thread that listens for
+// * incoming connections, a thread for connecting with a device, and a
+// * thread for performing data transmissions when connected.
+// *
+// * This code was based on the Android SDK BluetoothChat Sample
+// * $ANDROID_SDK/samples/android-17/BluetoothChat
+// */
+//public class BluetoothSerialService {
+//
+//    // Debugging
+//    private static final String TAG = "AB";// "BluetoothSerialService";
+//    private static final boolean D = true;
+//
+//    // Name for the SDP record when creating server socket
+//    private static final String NAME_SECURE = "PhoneGapBluetoothSerialServiceSecure";
+//    private static final String NAME_INSECURE = "PhoneGapBluetoothSerialServiceInSecure";
+//
+//    // Unique UUID for this application
+//    private static final UUID MY_UUID_SECURE = UUID.fromString("7A9C3B55-78D0-44A7-A94E-A93E3FE118CE");
+//    private static final UUID MY_UUID_INSECURE = UUID.fromString("23F18142-B389-4772-93BD-52BDBB2C03E9");
+//
+//    // Well known SPP UUID
+//    private static final UUID UUID_SPP = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
+//
+//    // Member fields
+//    private final BluetoothAdapter mAdapter;
+//    private final Handler mHandler;
+//    private AcceptThread mSecureAcceptThread;
+//    private AcceptThread mInsecureAcceptThread;
+//    private ConnectThread mConnectThread;
+//    private ConnectedThread mConnectedThread;
+//    private int mState;
+//    private /*final*/ BluetoothSocket mmSocket;
+//
+//    // Constants that indicate the current connection state
+//    public static final int STATE_NONE = 0;       // we're doing nothing
+//    public static final int STATE_LISTEN = 1;     // now listening for incoming connections
+//    public static final int STATE_CONNECTING = 2; // now initiating an outgoing connection
+//    public static final int STATE_CONNECTED = 3;  // now connected to a remote device
+//    private Timer bluetooth_timer = null;
+//    private int bluetooth_timeout=2*1000*60;
+//    private InputStream in=null;
+//    private OutputStream out=null;
+//    private android.bluetooth.BluetoothDevice bluetoothDevice;
+//    private int plen = 0;
+//    private int[] PATIENTINFO_PACKET_HEADER = new int[]{80, 87, 67, 65, 80, 73};  //PWCAPI
+//    private int dataBPPacketSize=10; // BP
+//    private int dataWeightPacketSize=14; // Weight
+//    private Date connectionTime=null;
+//    private SPPAcceptThread mInsecureSPPAcceptThread;
+//
+//    public int getDataPacketLength(){return plen;}
+//
+//    // private BluetoothBroadcastReceiver actionFoundReceiver;
+//    /**
+//     * Constructor. Prepares a new BluetoothSerial session.
+//     * @param handler  A Handler to send messages back to the UI Activity
+//     */
+//    public BluetoothSerialService(Handler handler) {
+//        mAdapter = BluetoothAdapter.getDefaultAdapter();
+//        mState = STATE_NONE;
+//        mHandler = handler;
+//        if (mInsecureSPPAcceptThread != null) {
+//            mInsecureSPPAcceptThread.cancel();
+//            mInsecureSPPAcceptThread = null;
+//        }
+//
+//    }
+//
+//        public synchronized BluetoothDevice getConnectedDevice() {
+//        return bluetoothDevice;
+//    }
+////    public void registerStateChangeReceiver(Context context) {
+////
+////
+////        //nehal
+////        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+////        // filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+////        // filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
+////        // filter.addAction(BluetoothDevice.ACTION_FOUND);
+////        actionFoundReceiver = new BluetoothBroadcastReceiver();
+////        context.registerReceiver(actionFoundReceiver, filter);
+////    }
+//
+//    /**
+//     * Set the current state of the chat connection
+//     * @param state  An integer defining the current connection state
+//     */
+//    private synchronized void setState(int state) {
+//        if (D) Log.d(TAG, "setState() " + mState + " -> " + state);
+//        mState = state;
+//
+//        // Give the new state to the Handler so the UI Activity can update
+//        mHandler.obtainMessage(BluetoothSerial.MESSAGE_STATE_CHANGE, state, -1).sendToTarget();
+//    }
+//
+//    /**
+//     * Return the current connection state. */
+//    public synchronized int getState() {
+//        return mState;
+//    }
+////
+////    public synchronized BluetoothDevice getConnectedDevice() {
+////        return bluetoothDevice;
+////    }
+//
+//    public synchronized void setStateNone() { // rename disconnect
+//        mState = STATE_NONE;
+//
+//        //send device name.. if device matches, cleanup ...first do logging
+//        if(bluetoothDevice!=null) {
+//            Log.d("AB", "SET STATE NONE for DEVICE " + bluetoothDevice.getName());
+//        }
+//        // devcie ka object bhi null
+//    }
+//
+//
+//
+//    /**
+//     * Start the chat service. Specifically start AcceptThread to begin a
+//     * session in listening (server) mode. Called by the Activity onResume() */
+//    public synchronized void start(BluetoothDevice device) {
+//        if (D) Log.d(TAG, "##################### STARTING SERIAL SERVICE AGAIN ####################");
+//        if(device!=null)
+//            Log.d("AB", "Bluetooh Serial Service START --- device --- " + device.getName());
+////        if (
+////            // this is specifically for the A&D devices for the SPP listener mode
+////                device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+////        ) {
+////            startBluetoothSPPListener(device);
+////        } else {
+//        // Cancel any thread attempting to make a connection
+//        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+//
+//        // Cancel any thread currently running a connection
+//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+//
+//        setState(STATE_NONE);
+//
+//        if (
+//            // this is specifically for the A&D devices for the SPP listener mode
+//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+//        ) {
+//            if (mInsecureSPPAcceptThread != null) {
+//                mInsecureSPPAcceptThread.cancel();
+//                mInsecureSPPAcceptThread = null;
+//            }
+//           //  startBluetoothSPPListener(device);
+//            mInsecureSPPAcceptThread = new SPPAcceptThread(device);
+//            mInsecureSPPAcceptThread.start();
+//        }
+//
+//        //       }
+//    }
+//
+//    /**
+//     * This thread runs while listening for incoming connections. It behaves
+//     * like a server-side client. It runs until a connection is accepted
+//     * (or until cancelled).
+//     */
+//    public class SPPAcceptThread extends Thread {
+//        // The local server socket
+//        public /*final*/ BluetoothServerSocket bluetoothSocket;
+//        private String mSocketType;
+//        private boolean keepSPPThreadRunning;
+//       private BluetoothSocket bs;
+//       private BluetoothDevice sppbtDevice;
+//
+//        public SPPAcceptThread(/*boolean secure*/ BluetoothDevice bluetoothDevice) {
+//            sppbtDevice = bluetoothDevice;
+//            Log.d("AB", "SPP Accept thread device" + sppbtDevice);
+//            keepSPPThreadRunning = true;
+////            BluetoothServerSocket tmp = null;
+////            mSocketType = "Insecure"; //secure ? "Secure":"Insecure";
+////            // Create a new listening server socket
+////            try {
+////                mmServerSocket =mAdapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
+////            } catch (IOException e) {
+////                Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
+////            }
+////            // mmServerSocket = tmp;
+//        }
+//        public void run() {
+//            try{
+//                Log.d(TAG, "Starting listening mode");
+//                BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+////                stopSPPThread = true;
+//                while(/*true*/ keepSPPThreadRunning) {
+//
+//                    Log.d("AB", "SPP Thread running ----------> ");
+//                    try {
+//                        /* BluetoothServerSocket*/
+//                        bluetoothSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
+////                    final BluetoothSocket bs=bluetoothSocket.accept();
+//                        /*final BluetoothSocket*/
+//                        bs = bluetoothSocket.accept();
+//                    }catch (IOException ex){
+//                        Log.d(TAG,"SPP Listener Run: bluetoothSocket" + ex.getMessage());
+//                        Thread.sleep(1000);
+//                        continue;
+//                    }
+//
+//                    if (bs == null) {
+//                        try {
+//                            closeConnection();
+//                        } catch(Exception e) {
+//                            Log.d(TAG,"CLOSE SPP connection---", e);
+//                        }
+//                    }
+//                    bluetoothSocket.close();
+//
+//                    Log.d(TAG, "Incoming bluetooth connection");
+//                    Thread bst = new Thread(new Runnable(){
+//
+//                        @Override
+//                        public void run() {
+//                            try{
+//                                Log.d(TAG, "startBluetoothSPPListener DEVICE : " + sppbtDevice.getName());
+//                                BluetoothDevice btDevice = sppbtDevice; //TODO this global instance changes frequently and this is causing issue
+//                                String deviceType = "";
+//                                try{
+//                                    String deviceAddr = btDevice.getAddress();
+//                                    //found connected device profile, get results
+//                                    Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
+//                                    if (btDevice.getName().contains("UA-767")) {
+//                                        deviceType = "bloodpressure";
+//                                    } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
+//                                        deviceType = "scale";
+//                                    }
+//                                    onConnection(bs);
+//                                    readData(bs, deviceType);
+//                                }
+//                                catch(Exception e){
+//                                    Log.d(TAG,"Error finding bluetooth device" + e);
+//                                }
+//                            }
+//                            catch(Exception e){
+//                                Log.d(TAG,"Bluetooth Socket Error", e);
+//                            }
+//                        }
+//
+//                    });
+//                    bst.start();
+//                }
+//            }
+//            catch(Exception e){
+//                Log.d(TAG,"Bluetooth Listener Error",e);
+//            }
+//
+//        }
+//        public void cancel() {
+//            if (D) Log.d(TAG, "Socket Type" + mSocketType + "cancel " + this);
+//
+//                Log.d("AB", "CANCELNG SPP-----");
+//
+//                keepSPPThreadRunning = true;
+//            try {
+//                Log.d("AB", "1....CANCELNG SPP-----");
+//                if(bs!=null) {
+//                    bs.close();
+//                    bs=null;
+//                }
+//                Log.d("AB", "222...CANCELNG SPP-----");
+//            } catch (IOException e) {
+//                Log.e(TAG, "SPP thread cancel" + bs + "close() of socket failed", e);
+//            }
+////            try{
+////                bluetoothSocket.close();
+////                Log.d("AB", "3....CANCELNG SPP-----");
+////            } catch (IOException e) {
+////                Log.e(TAG, "SPP thread cancel" + bs + "close() of socket failed", e);
+////            }
+//        }
+//    }
+//
+//    private void startBluetoothSPPListener(BluetoothDevice device){
+//        //start the bluetooth listener as its own thread
+//        //this listener checks for all incoming bluetooth connections and invokes the proper class object associated with that device
+//
+//        if(device!=null)
+//            Log.d("AB", "~~~~~~~ Start Bluetooth SPP Listener --- device --- " + device.getName());
+//
+//        Thread adt=new Thread(new Runnable(){
+//            @Override
+//            public void run() {
+//                try{
+//                    Log.d(TAG, "Starting listening mode");
+//                    BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+//                    while(true) {
+//                        BluetoothServerSocket bluetoothSocket=adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
+//                        final BluetoothSocket bs=bluetoothSocket.accept();
+//                        if (bs == null) {
+//                            try {
+//                                closeConnection();
+//                            } catch(Exception e) {
+//                                Log.d(TAG,"CLOSE SPP connection---", e);
+//                            }
+//                        }
+//                        bluetoothSocket.close();
+//
+//                        Log.d(TAG, "Incoming bluetooth connection");
+//                        Thread bst = new Thread(new Runnable(){
+//
+//                            @Override
+//                            public void run() {
+//                                try{
+//                                    Log.d(TAG, "startBluetoothSPPListener DEVICE : " + device.getName());
+//                                    BluetoothDevice btDevice = device; //TODO this global instance changes frequently and this is causing issue
+//                                    String deviceType = "";
+//                                    try{
+//                                        String deviceAddr = btDevice.getAddress();
+//                                        //found connected device profile, get results
+//                                        Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
+//                                        if (btDevice.getName().contains("UA-767")) {
+//                                            deviceType = "bloodpressure";
+//                                        } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
+//                                            deviceType = "scale";
+//                                        }
+//                                        onConnection(bs);
+//                                        readData(bs, deviceType);
+//                                    }
+//                                    catch(Exception e){
+//                                        Log.d(TAG,"Error finding bluetooth device" + e);
+//                                    }
+//                                }
+//                                catch(Exception e){
+//                                    Log.d(TAG,"Bluetooth Socket Error", e);
+//                                }
+//                            }
+//
+//                        });
+//                        bst.start();
+//                    }
+//                }
+//                catch(Exception e){
+//                    Log.d(TAG,"Bluetooth Listener Error",e);
+//                }
+//            }
+//
+//
+//
+//        });
+//        adt.start();
+//    }
+//
+//    /**
+//     * Start the ConnectThread to initiate a connection to a remote device.
+//     * @param device  The BluetoothDevice to connect
+//     * @param secure Socket Security type - Secure (true) , Insecure (false)
+//     */
+//    public synchronized void connect(BluetoothDevice device, boolean secure) {
+//        if (D) Log.d(TAG, "connect to: " + device);
+//        bluetoothDevice = device;
+//
+//        if(device!=null)
+//            Log.d("AB", "Bluetooh Serial Service CONNECT --- device --- " + device.getName());
+//
+//        // Cancel any thread attempting to make a connection
+//        if (mState == STATE_CONNECTING) {
+//            if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+//        }
+//
+//        // Cancel any thread currently running a connection
+//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+//
+//        // Start the thread to connect with the given device
+//        mConnectThread = new ConnectThread(device, secure);
+//        mConnectThread.start();
+//        setState(STATE_CONNECTING);
+//    }
+//
+//    /**
+//     * Start the ConnectedThread to begin managing a Bluetooth connection
+//     * @param socket  The BluetoothSocket on which the connection was made
+//     * @param device  The BluetoothDevice that has been connected
+//     */
+//    public synchronized void connected(BluetoothSocket socket, BluetoothDevice device, final String socketType) {
+//        if (D) Log.d(TAG, "connected, Socket Type:" + socketType);
+//
+//        // Cancel the thread that completed the connection
+//        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
+//
+//        // Cancel any thread currently running a connection
+//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
+//
+//        // Cancel the accept thread because we only want to connect to one device
+//        if (mSecureAcceptThread != null) {
+//            mSecureAcceptThread.cancel();
+//            mSecureAcceptThread = null;
+//        }
+//        if (mInsecureAcceptThread != null) {
+//            mInsecureAcceptThread.cancel();
+//            mInsecureAcceptThread = null;
+//        }
+//
+////        if (mInsecureSPPAcceptThread != null) {
+////            mInsecureSPPAcceptThread.cancel();
+////            mInsecureSPPAcceptThread = null;
+////        }
+//
+//        // Start the thread to manage the connection and perform transmissions
+//        if (
+//            !device.getName().contains("UA-767") &&
+//                !device.getName().contains("UC-355") &&
+//                !device.getName().contains("UC-351")
+//        ) {
+//            mConnectedThread = new ConnectedThread(socket, socketType, device);
+//            mConnectedThread.start();
+//        }
+//
+//        // Send the name of the connected device back to the UI Activity
+//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
+//        Bundle bundle = new Bundle();
+//        bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
+//        msg.setData(bundle);
+//        mHandler.sendMessage(msg);
+//
+//        setState(STATE_CONNECTED);
+//    }
+//
+//
+//
+//    /**
+//     * Stop all threads
+//     */
+//    public synchronized void stop() {
+//        if (D) Log.d(TAG, "stop");
+//
+//        if(bluetoothDevice!=null)
+//            Log.d("AB", "Bluetooh Serial Service STOP --- device --- " + bluetoothDevice.getName());
+//
+//        if (mConnectThread != null) {
+//            mConnectThread.cancel();
+//            mConnectThread = null;
+//        }
+//
+//        if (mConnectedThread != null) {
+//            mConnectedThread.cancel();
+//            mConnectedThread = null;
+//        }
+//
+//        if (mSecureAcceptThread != null) {
+//            mSecureAcceptThread.cancel();
+//            mSecureAcceptThread = null;
+//        }
+//
+//        if (mInsecureAcceptThread != null) {
+//            mInsecureAcceptThread.cancel();
+//            mInsecureAcceptThread = null;
+//        }
+//
+//        if (mInsecureSPPAcceptThread != null) {
+//            mInsecureSPPAcceptThread.cancel();
+//            mInsecureSPPAcceptThread = null;
+//        }
+//
+//        //close our code changes open connections also
+////        try {
+////            closeBluetoothConnection();
+////        } catch (IOException e) {
+////            e.printStackTrace();
+////        }
+////
+////        bst = null;
+////        adt = null;
+//
+//
+//        setState(STATE_NONE);
+//    }
+//
+//    /**
+//     * Write to the ConnectedThread in an unsynchronized manner
+//     * @param out The bytes to write
+//     * @see ConnectedThread#write(byte[])
+//     */
+//    public void write(byte[] out) {
+//        // Create temporary object
+//        ConnectedThread r;
+//        // Synchronize a copy of the ConnectedThread
+//        synchronized (this) {
+//            if (mState != STATE_CONNECTED) return;
+//            r = mConnectedThread;
+//        }
+//        // Perform the write unsynchronized
+//        r.write(out);
+//    }
+//
+//    /**
+//     * Indicate that the connection attempt failed and notify the UI Activity.
+//     */
+//    private void connectionFailed() {
+//        // Send a failure message back to the Activity
+//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+//        Bundle bundle = new Bundle();
+//        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
+//        msg.setData(bundle);
+//        mHandler.sendMessage(msg);
+//
+//        // Start the service over to restart listening mode
+//        Log.d("AB", "Connection Failed Bluetooth serial service RESTART ");
+//        BluetoothSerialService.this.start(null);
+//    }
+//
+//    /**
+//     * Indicate that the connection was lost and notify the UI Activity.
+//     */
+//    private void connectionLost() {
+//        // Send a failure message back to the Activity
+//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+//        Bundle bundle = new Bundle();
+//        bundle.putString(BluetoothSerial.TOAST, "Device connection was lost");
+//        msg.setData(bundle);
+//        mHandler.sendMessage(msg);
+//
+//        // Start the service over to restart listening mode
+//        Log.d("AB", "Connection Lost Bluetooth serial service RESTART ");
+//        BluetoothSerialService.this.start(null);
+//    }
+//
+//    /**
+//     * This thread runs while listening for incoming connections. It behaves
+//     * like a server-side client. It runs until a connection is accepted
+//     * (or until cancelled).
+//     */
+//    private class AcceptThread extends Thread {
+//        // The local server socket
+//        private final BluetoothServerSocket mmServerSocket;
+//        private String mSocketType;
+//
+//        public AcceptThread(boolean secure) {
+//            BluetoothServerSocket tmp = null;
+//            mSocketType = secure ? "Secure":"Insecure";
+//
+//            // Create a new listening server socket
+//            try {
+//                if (secure) {
+//                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);
+//                } else {
+//                    tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
+//                }
+//            } catch (IOException e) {
+//                Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
+//            }
+//            mmServerSocket = tmp;
+//        }
+//
+//        public void run() {
+//            if (D) Log.d(TAG, "Socket Type: " + mSocketType + "BEGIN mAcceptThread" + this);
+//            setName("AcceptThread" + mSocketType);
+//
+//            BluetoothSocket socket;
+//
+//            // Listen to the server socket if we're not connected
+//            while (mState != STATE_CONNECTED) {
+//                try {
+//                    // This is a blocking call and will only return on a
+//                    // successful connection or an exception
+//                    socket = mmServerSocket.accept();
+//                } catch (IOException e) {
+//                    Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
+//                    break;
+//                }
+//
+//                // If a connection was accepted
+//                if (socket != null) {
+//                    synchronized (BluetoothSerialService.this) {
+//                        switch (mState) {
+//                            case STATE_LISTEN:
+//                            case STATE_CONNECTING:
+//                                // Situation normal. Start the connected thread.
+//                                connected(socket, socket.getRemoteDevice(),
+//                                    mSocketType);
+//                                break;
+//                            case STATE_NONE:
+//                            case STATE_CONNECTED:
+//                                // Either not ready or already connected. Terminate new socket.
+//                                try {
+//                                    socket.close();
+//                                } catch (IOException e) {
+//                                    Log.e(TAG, "Could not close unwanted socket", e);
+//                                }
+//                                break;
+//                        }
+//                    }
+//                }
+//            }
+//            if (D) Log.i(TAG, "END mAcceptThread, socket Type: " + mSocketType);
+//
+//        }
+//
+//        public void cancel() {
+//            if (D) Log.d(TAG, "Socket Type" + mSocketType + "cancel " + this);
+//            try {
+//                mmServerSocket.close();
+//            } catch (IOException e) {
+//                Log.e(TAG, "Socket Type" + mSocketType + "close() of server failed", e);
+//            }
+//        }
+//    }
+//
+//
+//    /**
+//     * This thread runs while attempting to make an outgoing connection
+//     * with a device. It runs straight through; the connection either
+//     * succeeds or fails.
+//     */
+//    private class ConnectThread extends Thread {
+//        private /*final*/ BluetoothSocket mmSocket;
+//        private final BluetoothDevice mmDevice;
+//        private String mSocketType;
+//
+//        public ConnectThread(BluetoothDevice device, boolean secure) {
+//            mmDevice = device;
+//            BluetoothSocket tmp = null;
+//            if ( //nehal
+//                device.getName().contains("UA-767") ||
+//                    device.getName().contains("UC-355") ||
+//                    device.getName().contains("UC-351")
+//            ) {
+//                secure = false;
+//            }
+//
+//            mSocketType = secure ? "Secure" : "Insecure";
+//
+//
+//
+////            // Get a BluetoothSocket for a connection with the given BluetoothDevice
+////            if (
+////                !device.getName().contains("UA-767") &&
+////                    !device.getName().contains("UC-355") &&
+////                    !device.getName().contains("UC-351")
+////            ) {
+//                // Get a BluetoothSocket for a connection with the given BluetoothDevice
+//                try {
+//                    if (secure) {
+//                        tmp = device.createRfcommSocketToServiceRecord(UUID_SPP);
+//                    } else {
+//                        tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+//                    }
+//                } catch (IOException e) {
+//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
+//                }
+//
+//
+//                // mAdapter.cancelDiscovery();
+////            } else {
+////                try {
+////                    //  mAdapter.cancelDiscovery();
+////                    tmp = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
+////                    //  tmp.connect();
+////                } catch ( NoSuchMethodException e) {
+////                  //  retryConnection();
+////                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
+////                } catch (IllegalAccessException e) {
+////                    e.printStackTrace();
+////                } catch (InvocationTargetException e) {
+////                    e.printStackTrace();
+////                }
+////
+////            }
+//            mmSocket = tmp;
+//        }
+//
+//
+//        public void run() {
+//            Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
+//            setName("ConnectThread" + mSocketType);
+//           // BluetoothSocket tmp = mmSocket;
+////            if (
+////                    !mmDevice.getName().contains("UA-767") &&
+////                            !mmDevice.getName().contains("UC-355") &&
+////                            !mmDevice.getName().contains("UC-351")
+////            ) {
+//            // Always cancel discovery because it will slow down a connection
+//          //  mAdapter.cancelDiscovery();
+//
+//            // Make a connection to the BluetoothSocket
+//            try {
+//                // This is a blocking call and will only return on a successful connection or an exception
+//                Log.i(TAG,"Connecting to socket...");
+////                tmp = mmSocket;
+//                mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
+//                mmSocket.connect();
+//                Log.i(TAG,"Connected");
+//            } catch (IOException | NoSuchMethodException e) {
+//                Log.e(TAG, e.toString());
+//
+////                if(mmSocket != null) {
+////                    try {
+////                        mmSocket.close();
+////                    } catch (IOException e1) {
+////                        Log.d("AB", "Closing and null the socket");
+////
+////                        e1.printStackTrace();
+////                    }
+////                    mmSocket = null;
+////                }
+//                // Some 4.1 devices have problems, try an alternative way to connect
+//                // See https://github.com/don/BluetoothSerial/issues/89
+//                    try {
+//                            if (mSocketType.equalsIgnoreCase("Secure")) {
+//                                mmSocket = mmDevice.createRfcommSocketToServiceRecord(UUID_SPP);
+//                            } else {
+//                                mmSocket = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+//                            }
+//                        Log.i(TAG,"Trying fallback...");
+////                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
+//                        mmSocket.connect();
+//                        Log.i(TAG,"Connected");
+//                    } catch (Exception e2) {
+//                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
+//
+//
+//                                        try {
+//                                            mmSocket.close();
+//                                            closeConnection();
+//                                        } catch (IOException e3) {
+//                                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+//                                        }
+////                        if (
+////                            !mmDevice.getName().contains("UA-767") &&
+////                                !mmDevice.getName().contains("UC-355") &&
+////                                !mmDevice.getName().contains("UC-351")
+////                        ) {
+//                                        connectionFailed();
+//
+//
+//                    //    }
+//                    //    }
+//                        return;
+//                    }
+//          //      }
+//            } catch (IllegalAccessException e) {
+//                e.printStackTrace();
+//            }
+//            catch (InvocationTargetException e) {
+//                e.printStackTrace();
+//            }
+//
+//            // Reset the ConnectThread because we're done
+//            synchronized (BluetoothSerialService.this) {
+//                mConnectThread = null;
+//            }
+//
+//            // Start the connected thread
+//            connected(mmSocket, mmDevice, mSocketType);
+//        }
+//
+//        public void cancel() {
+//            try {
+//                mmSocket.close();
+//            } catch (IOException e) {
+//                Log.e(TAG, "close() of connect " + mSocketType + " socket failed", e);
+//            }
+//        }
+//
+//        private void retryConnection() {
+////            JSONArray deviceList = new JSONArray();
+////            Set<BluetoothDevice> bondedDevices = mAdapter.getBondedDevices();
+////            if(bondedDevices.contains(mmDevice)) {
+////                Log.d("AB", mmDevice.getName() + " is bonded so not retrying it ");
+////            } else {
+//
+//            Log.d("AB", mmDevice.getName() + "  retrying it ");
+//
+//
+//            try {
+//                Log.i(TAG, "111 Trying fallback...");
+////                    mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
+////                    mmSocket.connect();
+//                mmSocket = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+//                mmSocket.connect();
+//                Log.i(TAG, "Connected");
+//            } catch (Exception e2) {
+//                Log.e(TAG, "Couldn't establish a Bluetooth connection.");
+//
+//
+//                try {
+//                    mmSocket.close();
+//                    closeConnection();
+//                } catch (IOException e3) {
+//                    Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+//                }
+//                Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+//                Bundle bundle = new Bundle();
+//                bundle.putString(BluetoothSerial.TOAST, "MMMM Unable to connect to device");
+//                msg.setData(bundle);
+//                mHandler.sendMessage(msg);
+//            }
+//            //      }
+//        }
+//
+//    }
+//
+//    private void connectToDevice(BluetoothSocket socket) throws IOException {
+//        mmSocket = socket;
+//        bluetoothDevice = socket.getRemoteDevice();
+//        if(bluetoothDevice!=null)
+//            Log.d("AB", "Service -- Connect To Device ---- " + bluetoothDevice.getName());
+//        Log.d(TAG, "bluetoothDevice CONNECTED OR NOT: " + socket.isConnected());
+//        in = socket.getInputStream();
+//        out = socket.getOutputStream();
+//        Log.d(TAG, "out: " + out);
+//    }
+//
+//    private void readPatientInfoPacket() throws IOException{
+//        // Check the packet type...
+//        int pktType1 = in.read();
+//        int pktType2 = in.read();
+//        int pktType = pktType1 + shift(pktType2,8);
+//        Log.d(TAG,"packet type: " + pktType);
+//
+//
+//        //if packet type is not the data packet, then read in and discard header packet
+//        if (pktType != 2) {
+//            Log.d(TAG,"skipping patient info packet...");
+//            //this is a patient info packet, skip the next 28 bytes
+//            boolean packetend = false;
+//            int lookfor = 0;
+//            while (!packetend) {
+//                int b = in.read();
+//                if (b == PATIENTINFO_PACKET_HEADER[lookfor]) {
+//                    lookfor++;
+//                }
+//                else if (lookfor > 0) {
+//                    lookfor = 0;
+//                }
+//
+//                if (lookfor == PATIENTINFO_PACKET_HEADER.length) {
+//                    packetend = true;
+//                }
+//            }
+//            Log.d(TAG,"end of patient info packet found...");
+//
+//            //now start the packet read over again
+//            pktType1 = in.read();
+//            pktType2 = in.read();
+//            pktType = pktType1 + shift(pktType2,8);
+//
+//        }
+//    }
+//
+//    public static int shift(int val, int shift){
+//        return (val << shift);
+//    }
+//
+//    private void readPatientPacket() throws IOException{
+//        // Check the packet length...
+//        plen = in.read() + shift(in.read(),8) + shift(in.read(),16) + shift(in.read(),24);
+//        Log.d(TAG,"packet len: " + plen);
+//
+//        //read devtype
+//        int devType = in.read() + shift(in.read(),8);
+//        Log.d(TAG,"devtype: " + devType);
+//// transmittingDeviceName = devType;
+//        //get flag
+//        int flag = in.read();
+//        Log.d(TAG,"flag: " + flag);
+//
+//        //get time of measurement
+//        int myear = in.read() + shift(in.read(),8);
+//        int mmonth = in.read();
+//        int mday = in.read();
+//        int mhour = in.read();
+//        int mmin = in.read();
+//        int msec = in.read();
+//        Log.d(TAG,"measurement time: " + mday + "/" + mmonth + "/" + myear + " " + mmin + ":" + msec);
+//
+//        //get time of transmission
+//        int tyear = in.read() + shift(in.read(),8);
+//        int tmonth = in.read();
+//        int tday = in.read();
+//        int thour = in.read();
+//        int tmin = in.read();
+//        int tsec = in.read();
+//        Log.d(TAG,"transmission time: " + tday + "/" + tmonth + "/" + tyear + " " + tmin + ":" + tsec);
+//
+//        Date measurementDate=new Date();
+//        Date transmissionDate=(Date)measurementDate.clone();
+//        measurementDate.setYear(myear-1900);
+//        measurementDate.setMonth(mmonth-1);
+//        measurementDate.setDate(mday);
+//        measurementDate.setHours(mhour);
+//        measurementDate.setMinutes(mmin);
+//        measurementDate.setSeconds(msec);
+//        transmissionDate.setYear(tyear-1900);
+//        transmissionDate.setMonth(tmonth-1);
+//        transmissionDate.setDate(tday);
+//        transmissionDate.setHours(thour);
+//        transmissionDate.setMinutes(tmin);
+//        transmissionDate.setSeconds(tsec);
+//
+//        //get bluetooth id of device
+//        int id0 = in.read();
+//        int id1 = in.read();
+//        int id2 = in.read();
+//        int id3 = in.read();
+//        int id4 = in.read();
+//        int id5 = in.read();
+//        Log.d(TAG,"bluetooth id: " + id0 + ":" + id1 + ":" + id2 + ":" + id3 + ":" + id4 + ":" + id5);
+//
+//        //get device name and serial number
+//        String devnameupper = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
+//
+//
+//        String devserial = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
+//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
+//        String devnamelower = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
+//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
+//
+////        Log.d("AB", "Dev name upper "+ devnameupper);
+////        Log.d("AB", "Dev serial number "+ devserial);
+// //       Log.d("AB", "Dev name lower "+ devnamelower);
+//
+//        //device battery status
+//        int batterystatus = in.read();
+//        Log.d(TAG,"battery status: " + batterystatus);
+//
+//        //skip reserved byte
+//        in.skip(1);
+//
+//        //get device firmware/hardware
+//        int devfirmwarehardware = in.read();
+//    }
+////private int transmittingDeviceName ;
+//
+//    public void onConnection(BluetoothSocket socket) throws IOException {
+//        Log.d(TAG, "onConnection" + socket);
+//        connectionTime = new Date();
+//        if (socket!=null) {
+//            in = socket.getInputStream();
+//            out = socket.getOutputStream();
+//            restartBluetoothTimeout(socket);
+//        }
+//    }
+//
+//    private void readData(BluetoothSocket socket, String deviceType) throws IOException{
+//        connectToDevice(socket);
+//        readPatientInfoPacket();
+//        readPatientPacket();
+//       // Log.d("AB", "transmittingDeviceName" + transmittingDeviceName);
+//      //  Log.d("AB", "deviceType" + deviceType);
+////        if(transmittingDeviceName== 767 || transmittingDeviceName ==766  ) {
+////            onBPDataPacket();
+////        }else if ( transmittingDeviceName== 355 || transmittingDeviceName== 351 || transmittingDeviceName ==322 /* 322*/ ) {
+////            onScaleDataPacket();
+////        } else {
+//            if (deviceType == "bloodpressure") {
+//                onBPDataPacket();
+//            } else {
+//                onScaleDataPacket();
+//            }
+//     //   }
+//        sendAcknowledgement();
+//        closeConnection();
+//    }
+//
+//    //bluetooth socket timeout functions
+//    protected void startBluetoothTimeout(BluetoothSocket socket){
+//        bluetooth_timer=new Timer();
+//        bluetooth_timer.schedule(new TimerTask() {
+//            @Override
+//            public void run() {
+//                //shut down the bluetooth socket
+//                Log.d(TAG,"bluetooth socket timeout...");
+//                try {
+//                    socket.close();
+//                } catch(Exception e) {}
+//            }
+//        }, bluetooth_timeout);
+//    }
+//    protected void cancelBluetoothTimeout(){
+//        try{
+//            bluetooth_timer.cancel();
+//            //nehal
+//            // setState(STATE_NONE);
+//        }
+//        catch(Exception e){}
+//    }
+//    protected void restartBluetoothTimeout(BluetoothSocket socket){
+//        cancelBluetoothTimeout();
+//        startBluetoothTimeout(socket);
+//    }
+//
+//    /**
+//     * This thread runs during a connection with a remote device.
+//     * It handles all incoming and outgoing transmissions.
+//     */
+//    private class ConnectedThread extends Thread {
+//        private final BluetoothSocket mmSocket;
+//        private final InputStream mmInStream;
+//        private final OutputStream mmOutStream;
+//        BluetoothDevice btDevice;
+//
+//        public ConnectedThread(BluetoothSocket socket, String socketType, BluetoothDevice device) {
+//            Log.d(TAG, "create ConnectedThread: " + socketType);
+//            btDevice = device;
+//            mmSocket = socket;
+//            InputStream tmpIn = null;
+//            OutputStream tmpOut = null;
+//
+//            // Get the BluetoothSocket input and output streams
+//            try {
+//                tmpIn = socket.getInputStream();
+//                tmpOut = socket.getOutputStream();
+//            } catch (IOException e) {
+//                Log.e(TAG, "temp sockets not created", e);
+//            }
+//
+//            mmInStream = tmpIn;
+//            mmOutStream = tmpOut;
+//        }
+//
+//        public void run() {
+//            Log.d(TAG, "ConnectedThread reading bytes");
+//            byte[] buffer = new byte[1024];
+//            int bytes;
+//
+//            // Keep listening to the InputStream while connected
+//            while (true) {
+//                try {
+//                    // Read from the InputStream
+//                    bytes = mmInStream.read(buffer);
+//                    String data = new String(buffer, 0, bytes);
+//
+//                    // Send the new data String to the UI Activity
+//                    mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ, data).sendToTarget();
+//
+//                    // Send the raw bytestream to the UI Activity.
+//                    // We make a copy because the full array can have extra data at the end
+//                    // when / if we read less than its size.
+//                    if (bytes > 0) {
+//                        byte[] rawdata = Arrays.copyOf(buffer, bytes);
+//                        mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ_RAW, rawdata).sendToTarget();
+//                    }
+//
+//                } catch (IOException e) {
+//                    Log.e(TAG, "disconnected", e);
+//                    connectionLost();
+//                    if(btDevice!=null)
+//                        Log.d("AB", "Connected Thread DISCONNECTED --- restarting Bluetooth service for device " + btDevice);
+//                    // Start the service over to restart listening mode
+//                    BluetoothSerialService.this.start(btDevice);
+//                    break;
+//                }
+//            }
+//        }
+//
+//        /**
+//         * Write to the connected OutStream.
+//         * @param buffer  The bytes to write
+//         */
+//        public void write(byte[] buffer) {
+//            try {
+//                mmOutStream.write(buffer);
+//
+//                // Share the sent message back to the UI Activity
+//                mHandler.obtainMessage(BluetoothSerial.MESSAGE_WRITE, -1, -1, buffer).sendToTarget();
+//
+//            } catch (IOException e) {
+//                Log.e(TAG, "Exception during write", e);
+//            }
+//        }
+//
+//        public void cancel() {
+//            try {
+//                mmSocket.close();
+//            } catch (IOException e) {
+//                Log.e(TAG, "close() of connect socket failed", e);
+//            }
+//        }
+//    }
+//
+//    public void onScaleDataPacket() throws IOException {
+//        //now get the scale data packet information
+//        int i = 0;
+//        String datastr = "";
+//        while (i < dataWeightPacketSize) {
+//            datastr = datastr + (char) in.read();
+//            i++;
+//        }
+//        Log.d(TAG,"scale data: " + datastr);
+//
+//        //if the reported length was more than 14, skip the rest of the data
+//        if (getDataPacketLength() > dataWeightPacketSize) {
+//            in.skip(getDataPacketLength() - dataWeightPacketSize);
+//        }
+//
+//        //parse reading
+//        double w = 0;
+//        String readingval = datastr.substring(4, 10);
+//        String readingtype = datastr.substring(10, 12);
+//        Log.d(TAG,"parsing: " + readingval);
+//        Log.d(TAG,"reading type: " + readingtype);
+//        //force lb as reading type
+//        if (readingtype.equals("lb")) {
+//            w = Double.valueOf(readingval);
+//            Log.d(TAG, "weight weight" + w);
+//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
+//            msg.obj = w;
+//            mHandler.sendMessage(msg);
+//        } else if (readingtype.equals("kg")){
+//            //convert kg to lbs
+//            w = Double.valueOf(readingval);
+//            w = kgTolbs(w);
+//            Log.d(TAG,"converted to lbs: " + w);
+//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
+//            msg.obj = w;
+//            mHandler.sendMessage(msg);
+//        }
+//
+//    }
+//
+//    //functions
+//    public static double kgTolbs(double kg){
+//        kg = kg * 2.20462;
+//        int kgi = (int)(kg*10);
+//        double lbs = (double)kgi/10.0;
+//        return lbs;
+//    }
+//
+//    public void onBPDataPacket() throws IOException {
+//        int i = 0;
+//        String datastr = "";
+//        while (i < dataBPPacketSize) {
+//            datastr = datastr + (char) in.read();
+//            i++;
+//        }
+//
+//        Log.d(TAG,"Datastring for blood pressure packet " + datastr);
+//
+//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
+//        msg.obj = datastr;
+//        mHandler.sendMessage(msg);
+//    }
+//
+//    private void sendAcknowledgement(){
+//        //now send response to acknowledge
+//        try{
+//            String msg = "PWA1";
+//            byte[] send = msg.getBytes();
+//            out.write(send);
+//            out.flush();
+//        }
+//        catch(Exception e){e.printStackTrace();}
+//    }
+//
+//    private void closeConnection() throws IOException{
+//        closeBluetoothConnection();
+//    }
+//
+//    protected void closeBluetoothConnection() throws IOException {
+//        try {
+//            in.close();
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//        }
+//        try {
+//            out.close();
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//        }
+////        if (mmSocket != null) {
+////            try {
+////                mmSocket.close();
+////            } catch (IOException e) {
+////                e.printStackTrace();
+////            }
+////            mmSocket = null;
+////        }
+//        // try{mmSocket.close();}catch(Exception e){e.printStackTrace();}
+//        cancelBluetoothTimeout();
+//        //nehal
+//        setState(STATE_NONE);
+//        if (bluetoothDevice != null)
+//            Log.d("AB", "Closing BT connectionss " + bluetoothDevice.getName());
+//        // bluetoothDevice = null;
+//    }
+//}
+//
+//// issues remaining ..
+////intermingling of data,...check data packet receievd
+////test with multiple devices and ble also
+//

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -485,6 +485,8 @@ public class BluetoothSerialService {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
                 mmSocket = tmp;
+
+                mAdapter.cancelDiscovery(); 
 //            } else {
 //                try {
 //                    tmp = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
@@ -507,7 +509,7 @@ public class BluetoothSerialService {
 //                            !mmDevice.getName().contains("UC-351")
 //            ) {
                 // Always cancel discovery because it will slow down a connection
-                mAdapter.cancelDiscovery();
+          //      mAdapter.cancelDiscovery();
 
                 // Make a connection to the BluetoothSocket
                 try {
@@ -527,12 +529,21 @@ public class BluetoothSerialService {
                         Log.i(TAG,"Connected");
                     } catch (Exception e2) {
                         Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-                        try {
-                            mmSocket.close();
-                        } catch (IOException e3) {
-                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-                        }
-                        connectionFailed();
+
+
+                                        try {
+                                            mmSocket.close();
+                                        } catch (IOException e3) {
+                                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+                                        }
+                        if (
+                            !mmDevice.getName().contains("UA-767") &&
+                                !mmDevice.getName().contains("UC-355") &&
+                                !mmDevice.getName().contains("UC-351")
+                        ) {
+                                        connectionFailed();
+
+                                    }
                         return;
                     }
                // }

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -872,19 +872,23 @@ public class BluetoothSerialService {
         setState(STATE_CONNECTED); //nehal new
         readPatientInfoPacket();
         int devType = readPatientPacket();
-        if(devType == 766 || deviceType.equals("bloodpressure")) { //device keeps on getting changed, recheck device frm data obtained
-            onBPDataPacket();
-        } else {
-            onScaleDataPacket();
-        }
+        Log.d(TAG, "## device type " + deviceType);
+
         if(socket!=null) {
             BluetoothDevice connectedBTDevice = socket.getRemoteDevice(); //gives the currently connected device
             if(connectedBTDevice!=null) {
-                Log.d("AB", "## connected BT device " + connectedBTDevice.getName());
+                Log.d(TAG, "## connected BT device " + connectedBTDevice.getName());
                 //Log.d("AB", "## staleinstace BT device " + bluetoothDevice.getName());
                 connectedBlueToothDevice = connectedBTDevice;
             }
         }
+        Log.d(TAG, " Connected device type " + connectedBlueToothDevice.getName());
+        if(devType == 766 || connectedBlueToothDevice.getName().contains("UA-767") /*|| deviceType.equals("bloodpressure")*/) { //device keeps on getting changed, recheck device frm data obtained
+            onBPDataPacket();
+        } else {
+            onScaleDataPacket();
+        }
+
 //        if (deviceType == "bloodpressure") { //string comparison
 //            onBPDataPacket();
 //        } else {

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -16,6 +17,10 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -76,7 +81,7 @@ public class BluetoothSerialService {
 
     public int getDataPacketLength(){return plen;}
 
-
+   // private BluetoothBroadcastReceiver actionFoundReceiver;
     /**
      * Constructor. Prepares a new BluetoothSerial session.
      * @param handler  A Handler to send messages back to the UI Activity
@@ -85,7 +90,21 @@ public class BluetoothSerialService {
         mAdapter = BluetoothAdapter.getDefaultAdapter();
         mState = STATE_NONE;
         mHandler = handler;
+
+
     }
+
+//    public void registerStateChangeReceiver(Context context) {
+//
+//
+//        //nehal
+//        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+//        // filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+//        // filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
+//        // filter.addAction(BluetoothDevice.ACTION_FOUND);
+//        actionFoundReceiver = new BluetoothBroadcastReceiver();
+//        context.registerReceiver(actionFoundReceiver, filter);
+//    }
 
     /**
      * Set the current state of the chat connection
@@ -110,12 +129,12 @@ public class BluetoothSerialService {
      * session in listening (server) mode. Called by the Activity onResume() */
     public synchronized void start(BluetoothDevice device) {
         if (D) Log.d(TAG, "start");
-        if (
-            // this is specifically for the A&D devices for the SPP listener mode
-                device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-        ) {
-            startBluetoothSPPListener(device);
-        } else {
+//        if (
+//            // this is specifically for the A&D devices for the SPP listener mode
+//                device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+//        ) {
+//            startBluetoothSPPListener(device);
+//        } else {
             // Cancel any thread attempting to make a connection
             if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
 
@@ -123,7 +142,15 @@ public class BluetoothSerialService {
             if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
 
             setState(STATE_NONE);
+
+        if (
+            // this is specifically for the A&D devices for the SPP listener mode
+            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+        ) {
+            startBluetoothSPPListener(device);
         }
+
+ //       }
     }
 
     private void startBluetoothSPPListener(BluetoothDevice device){
@@ -256,6 +283,8 @@ public class BluetoothSerialService {
 
         setState(STATE_CONNECTED);
     }
+
+
 
     /**
      * Stop all threads
@@ -427,14 +456,24 @@ public class BluetoothSerialService {
         public ConnectThread(BluetoothDevice device, boolean secure) {
             mmDevice = device;
             BluetoothSocket tmp = null;
+            if ( //nehal
+                device.getName().contains("UA-767") ||
+                    device.getName().contains("UC-355") ||
+                    device.getName().contains("UC-351")
+            ) {
+                secure = false;
+            }
+
             mSocketType = secure ? "Secure" : "Insecure";
 
+
+
             // Get a BluetoothSocket for a connection with the given BluetoothDevice
-            if (
-                    !device.getName().contains("UA-767") &&
-                            !device.getName().contains("UC-355") &&
-                            !device.getName().contains("UC-351")
-            ) {
+//            if (
+//                    !device.getName().contains("UA-767") &&
+//                            !device.getName().contains("UC-355") &&
+//                            !device.getName().contains("UC-351")
+//            ) {
                 // Get a BluetoothSocket for a connection with the given BluetoothDevice
                 try {
                     if (secure) {
@@ -446,27 +485,27 @@ public class BluetoothSerialService {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
                 mmSocket = tmp;
-            } else {
-                try {
-                    tmp = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-                    mAdapter.cancelDiscovery();
-                    tmp.connect();
-                } catch (IOException e) {
-                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-                }
-                mmSocket = tmp;
-            }
+//            } else {
+//                try {
+//                    tmp = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+//                    mAdapter.cancelDiscovery();
+//                    tmp.connect();
+//                } catch (IOException e) {
+//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
+//                }
+//                mmSocket = tmp;
+//            }
         }
 
         public void run() {
             Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
             setName("ConnectThread" + mSocketType);
 
-            if (
-                    !mmDevice.getName().contains("UA-767") &&
-                            !mmDevice.getName().contains("UC-355") &&
-                            !mmDevice.getName().contains("UC-351")
-            ) {
+//            if (
+//                    !mmDevice.getName().contains("UA-767") &&
+//                            !mmDevice.getName().contains("UC-355") &&
+//                            !mmDevice.getName().contains("UC-351")
+//            ) {
                 // Always cancel discovery because it will slow down a connection
                 mAdapter.cancelDiscovery();
 
@@ -496,7 +535,7 @@ public class BluetoothSerialService {
                         connectionFailed();
                         return;
                     }
-                }
+               // }
             }
 
             // Reset the ConnectThread because we're done

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -79,6 +79,9 @@ public class BluetoothSerialService {
 
     public int getDataPacketLength(){return plen;}
 
+    public void resetConnectedBTDevice() {
+        connectedBlueToothDevice = null;
+    }
 
     /**
      * Constructor. Prepares a new BluetoothSerial session.
@@ -130,6 +133,8 @@ public class BluetoothSerialService {
             device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
         ) {
           //   startBluetoothSPPListener(device);
+
+            resetConnectedBTDevice();
 
             if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
                 Log.d(TAG, "## SPP thread is alive!!!");
@@ -340,7 +345,7 @@ public class BluetoothSerialService {
      */
     public synchronized void connect(BluetoothDevice device, boolean secure) {
         if (D) Log.d(TAG, "connect to: " + device);
-        // bluetoothDevice = device;
+        bluetoothDevice = device;
 
         // Cancel any thread attempting to make a connection
         if (mState == STATE_CONNECTING) {
@@ -431,7 +436,8 @@ public class BluetoothSerialService {
             mInsecureAcceptThread = null;
         }
 
-
+        connectedBlueToothDevice = null;
+        Log.d("AB", "On service stop --- Made connected bluetooth device as null ");
         setState(STATE_NONE);
     }
 
@@ -1084,7 +1090,11 @@ public class BluetoothSerialService {
     }
 
     public synchronized BluetoothDevice getConnectedDevice() {
-        return connectedBlueToothDevice;
+        if (connectedBlueToothDevice!=null) {
+            return connectedBlueToothDevice;
+        } else {
+            return bluetoothDevice;
+        }
     }
 
     protected void closeBluetoothConnection()  {

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -74,6 +74,8 @@ public class BluetoothSerialService {
     private int dataBPPacketSize=10; // BP
     private int dataWeightPacketSize=14; // Weight
     private Date connectionTime=null;
+    private BluetoothDevice connectedBlueToothDevice;
+    private static SPPAcceptThread sppAcceptThread;
 
     public int getDataPacketLength(){return plen;}
 
@@ -115,7 +117,7 @@ public class BluetoothSerialService {
     public synchronized int getState() {
         return mState;
     }
-    private static SPPAcceptThread sppAcceptThread;
+
 
     /**
      * Start the chat service. Specifically start AcceptThread to begin a
@@ -128,20 +130,12 @@ public class BluetoothSerialService {
             device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
         ) {
           //   startBluetoothSPPListener(device);
-//            if(sppAcceptThread!=null) {
-//                Log.d("AB", "SPP Accept Thread OLD CANCELEEDED");
-//                sppAcceptThread.cancel();
-//                sppAcceptThread = null;
-//            }
-//            sppAcceptThread = new SPPAcceptThread(device);
-//            sppAcceptThread.start();
-//            Log.d("AB", "New SPP Thread created");
 
             if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
-                Log.d("AB", "## SPP thread is alive!!!");
+                Log.d(TAG, "## SPP thread is alive!!!");
                 sppAcceptThread.resetDevice(device);
             } else {
-                Log.d("AB", "## NEW SPP thread !!!");
+                Log.d(TAG, "## NEW SPP thread !!!");
                 sppAcceptThread = new SPPAcceptThread(device);
                 sppAcceptThread.start();
             }
@@ -162,45 +156,21 @@ public class BluetoothSerialService {
         setState(STATE_NONE);
     }
 
-    public void restartSPPAcceptThread(BluetoothDevice device) {
-        if (
-            // this is specifically for the A&D devices for the SPP listener mode
-            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-        ) {
-            //           startBluetoothSPPListener(device);
-//            if(sppAcceptThread!=null) {
-//                Log.d("AB", "SPP Accept Thread OLD CANCELEEDED");
-//                sppAcceptThread.cancel();
-//                sppAcceptThread = null;
-//            }
-//            if(sppAcceptThread!=null && sppAcceptThread.isAlive()) {
-//                sppAcceptThread.resetDevice(device);
-//            }else {
-//                sppAcceptThread = new SPPAcceptThread(device);
-//                sppAcceptThread.start();
-//            }
-            Log.d("AB", "New SPP Thread created");
-            //  setState(STATE_CONNECTED);
-        }
-    }
-
     private class SPPAcceptThread extends Thread {
-        private /*final*/ BluetoothServerSocket mmServerSocket;
+        private BluetoothServerSocket mmServerSocket;
         BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
         BluetoothDevice device;
 
         public void resetDevice(BluetoothDevice device) {
-            Log.d("AB", "## Resetting the device from " +  this.device.getName());
+            Log.d(TAG, "## Resetting the device from " +  this.device.getName());
             this.device = device;
-            Log.d("AB", "## Resetting the device to " + device.getName());
+            Log.d(TAG, "## Resetting the device to " + device.getName());
         }
 
         public SPPAcceptThread(BluetoothDevice device) {
-            // Use a temporary object that is later assigned to mmServerSocket,
-            // because mmServerSocket is final
             mmServerSocket = null;
             this.device = device;
-            Log.d("AB", "New SPP Accept thread for devcice" + device.getName());
+            Log.d(TAG, "New SPP Accept thread for device " + device.getName());
 //            try {
 //                mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
 //            } catch (IOException e) { }
@@ -217,15 +187,11 @@ public class BluetoothSerialService {
 
             while (true/* mState != STATE_CONNECTED*/) {
                 try {
-                    Log.d("AB", "----- > SPP accept thread ---> ");
-                  //  mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-                    socket = mmServerSocket.accept(); //mmServerSocket.accept(10000);
+                    Log.d(TAG, "----- > SPP accept thread ---> ");
+
+                    socket = mmServerSocket.accept();
                 } catch (IOException e) {
-                    Log.d("AB", "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
-
-                    //continue;
-
-                    // break;
+                    Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
                 }
 
                 // If a connection was accepted
@@ -233,7 +199,7 @@ public class BluetoothSerialService {
                     //synchronized (BluetoothSerialService.this) {
                         // Do work to manage the connection (in a separate thread)
                         try {
-                            Log.d("AB", " -- > SPP thread --> connection accepted -- > ");
+                            Log.d(TAG, " -- > SPP thread --> connection accepted -- > ");
                             BluetoothDevice btDevice = this.device; //device;
                             String deviceType = "";
                             try {
@@ -297,7 +263,7 @@ public class BluetoothSerialService {
             @Override
             public void run() {
                 try{
-                    bluetoothDevice = device; //new neahl
+                    bluetoothDevice = device;
                     Log.d(TAG, "Starting listening mode");
                     BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
                     while(true) {
@@ -328,7 +294,7 @@ public class BluetoothSerialService {
                             @Override
                             public void run() {
                                 try{
-                                    BluetoothDevice btDevice =   bluetoothDevice; //device;
+                                    BluetoothDevice btDevice =   connectedBlueToothDevice;//  bluetoothDevice; //device;
                                     String deviceType = "";
                                     try{
                                         String deviceAddr = btDevice.getAddress();
@@ -374,7 +340,7 @@ public class BluetoothSerialService {
      */
     public synchronized void connect(BluetoothDevice device, boolean secure) {
         if (D) Log.d(TAG, "connect to: " + device);
-        bluetoothDevice = device;
+        // bluetoothDevice = device;
 
         // Cancel any thread attempting to make a connection
         if (mState == STATE_CONNECTING) {
@@ -415,22 +381,6 @@ public class BluetoothSerialService {
             mInsecureAcceptThread.cancel();
             mInsecureAcceptThread = null;
         }
-
-//        if (
-//            // this is specifically for the A&D devices for the SPP listener mode
-//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-//        ) {
-//            //           startBluetoothSPPListener(device);
-//            if(sppAcceptThread!=null) {
-//                Log.d("AB", "SPP Accept Thread OLD CANCELEEDED");
-//                sppAcceptThread.cancel();
-//                sppAcceptThread = null;
-//            }
-//            sppAcceptThread = new SPPAcceptThread(device);
-//            sppAcceptThread.start();
-//            Log.d("AB", "New SPP Thread created");
-//            //  setState(STATE_CONNECTED);
-//        }
 
 
         // Start the thread to manage the connection and perform transmissions
@@ -685,6 +635,7 @@ public class BluetoothSerialService {
                     Log.i(TAG, "Connecting to socket...");
                     mmSocket.connect();
                     Log.i(TAG, "Connected");
+                    connectedBlueToothDevice = mmSocket.getRemoteDevice();
                 } catch (IOException e) {
                     Log.e(TAG, e.toString());
 
@@ -696,6 +647,7 @@ public class BluetoothSerialService {
                    //    mmSocket =(BluetoothSocket)  mmDevice.getClass().getMethod("createInsecureRfcommSocketToServiceRecord", new Class[] { UUID.class }).invoke(mmDevice, UUID_SPP);
                         mmSocket.connect();
                         Log.i(TAG, "Connected");
+                        connectedBlueToothDevice = mmSocket.getRemoteDevice();
                     } catch (Exception e2) {
                         Log.e(TAG, "Couldn't establish a Bluetooth connection.");
                         try {
@@ -715,6 +667,7 @@ public class BluetoothSerialService {
                     Log.i(TAG, "Connecting to socket...");
                     mmSocket.connect();
                     Log.i(TAG, "Connected");
+                    connectedBlueToothDevice = mmSocket.getRemoteDevice();
                 } catch (IOException e) {
                     Log.e(TAG, e.toString());
 
@@ -726,6 +679,7 @@ public class BluetoothSerialService {
 
                         mmSocket.connect();
                         Log.i(TAG, "Connected");
+                        connectedBlueToothDevice = mmSocket.getRemoteDevice();
                     } catch (Exception e2) {
                         Log.e(TAG, "Couldn't establish a Bluetooth connection.");
                         try {
@@ -753,13 +707,6 @@ public class BluetoothSerialService {
                     }
                 }
 
-                // Reset the ConnectThread because we're done
-//                synchronized (BluetoothSerialService.this) {
-//                    mConnectThread = null;
-//                }
-//
-//                // Start the connected thread
-//                connected(mmSocket, mmDevice, mSocketType);
             }
             synchronized (BluetoothSerialService.this) {
                 mConnectThread = null;
@@ -781,7 +728,7 @@ public class BluetoothSerialService {
 
     private void connectToDevice(BluetoothSocket socket) throws IOException {
         mmSocket = socket;
-        bluetoothDevice = socket.getRemoteDevice();
+        connectedBlueToothDevice = socket.getRemoteDevice();// bluetoothDevice = socket.getRemoteDevice();
         Log.d(TAG, "bluetoothDevice CONNECTED OR NOT: " + socket.isConnected());
         in = socket.getInputStream();
         out = socket.getOutputStream();
@@ -919,16 +866,24 @@ public class BluetoothSerialService {
         setState(STATE_CONNECTED); //nehal new
         readPatientInfoPacket();
         int devType = readPatientPacket();
-//        if(devType == 322) { //device keeps on getting changed, yaha se device bhi pass karna padege
-//            onScaleDataPacket();
-//        } else {
-//            onBPDataPacket();
-//        }
-        if (deviceType == "bloodpressure") {
+        if(devType == 766 || deviceType.equals("bloodpressure")) { //device keeps on getting changed, recheck device frm data obtained
             onBPDataPacket();
         } else {
             onScaleDataPacket();
         }
+        if(socket!=null) {
+            BluetoothDevice connectedBTDevice = socket.getRemoteDevice(); //gives the currently connected device
+            if(connectedBTDevice!=null) {
+                Log.d("AB", "## connected BT device " + connectedBTDevice.getName());
+                //Log.d("AB", "## staleinstace BT device " + bluetoothDevice.getName());
+                connectedBlueToothDevice = connectedBTDevice;
+            }
+        }
+//        if (deviceType == "bloodpressure") { //string comparison
+//            onBPDataPacket();
+//        } else {
+//            onScaleDataPacket();
+//        }
 
         sendAcknowledgement();
         closeConnection();
@@ -948,6 +903,7 @@ public class BluetoothSerialService {
 //            }
 //        }, bluetooth_timeout);
     }
+
     protected void cancelBluetoothTimeout(){
 //        try{
 //            bluetooth_timer.cancel();
@@ -980,6 +936,7 @@ public class BluetoothSerialService {
             try {
                 tmpIn = socket.getInputStream();
                 tmpOut = socket.getOutputStream();
+                connectedBlueToothDevice = socket.getRemoteDevice();
             } catch (IOException e) {
                 Log.e(TAG, "temp sockets not created", e);
             }
@@ -1127,1224 +1084,15 @@ public class BluetoothSerialService {
     }
 
     public synchronized BluetoothDevice getConnectedDevice() {
-        return bluetoothDevice;
+        return connectedBlueToothDevice;
     }
 
-    protected void closeBluetoothConnection() /*throws IOException*/ {
+    protected void closeBluetoothConnection()  {
         //try catching NPE for all before closing
         try{if(in!=null) {in.close();}}catch(Exception e){e.printStackTrace();}
         try{if(out!=null) {out.close();}}catch(Exception e){e.printStackTrace();}
         try{if(mmSocket!=null) {mmSocket.close();}}catch(Exception e){e.printStackTrace();}
         cancelBluetoothTimeout();
-        setState(STATE_NONE); //nehal new
+        setState(STATE_NONE);
     }
 }
-
-//package com.megster.cordova;
-//
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.io.OutputStream;
-//import java.lang.reflect.InvocationTargetException;
-//import java.util.Date;
-//import java.util.Timer;
-//import java.util.TimerTask;
-//import java.util.UUID;
-//import java.util.Arrays;
-//
-//import android.bluetooth.BluetoothAdapter;
-//import android.bluetooth.BluetoothDevice;
-//import android.bluetooth.BluetoothServerSocket;
-//import android.bluetooth.BluetoothSocket;
-//import android.os.Bundle;
-//import android.os.Handler;
-//import android.os.Message;
-//import android.util.Log;
-//
-//
-///**
-// * This class does all the work for setting up and managing Bluetooth
-// * connections with other devices. It has a thread that listens for
-// * incoming connections, a thread for connecting with a device, and a
-// * thread for performing data transmissions when connected.
-// *
-// * This code was based on the Android SDK BluetoothChat Sample
-// * $ANDROID_SDK/samples/android-17/BluetoothChat
-// */
-//public class BluetoothSerialService {
-//
-//    // Debugging
-//    private static final String TAG = "AB";// "BluetoothSerialService";
-//    private static final boolean D = true;
-//
-//    // Name for the SDP record when creating server socket
-//    private static final String NAME_SECURE = "PhoneGapBluetoothSerialServiceSecure";
-//    private static final String NAME_INSECURE = "PhoneGapBluetoothSerialServiceInSecure";
-//
-//    // Unique UUID for this application
-//    private static final UUID MY_UUID_SECURE = UUID.fromString("7A9C3B55-78D0-44A7-A94E-A93E3FE118CE");
-//    private static final UUID MY_UUID_INSECURE = UUID.fromString("23F18142-B389-4772-93BD-52BDBB2C03E9");
-//
-//    // Well known SPP UUID
-//    private static final UUID UUID_SPP = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
-//
-//    // Member fields
-//    private final BluetoothAdapter mAdapter;
-//    private final Handler mHandler;
-//    private AcceptThread mSecureAcceptThread;
-//    private AcceptThread mInsecureAcceptThread;
-//    private ConnectThread mConnectThread;
-//    private ConnectedThread mConnectedThread;
-//    private int mState;
-//    private /*final*/ BluetoothSocket mmSocket;
-//
-//    // Constants that indicate the current connection state
-//    public static final int STATE_NONE = 0;       // we're doing nothing
-//    public static final int STATE_LISTEN = 1;     // now listening for incoming connections
-//    public static final int STATE_CONNECTING = 2; // now initiating an outgoing connection
-//    public static final int STATE_CONNECTED = 3;  // now connected to a remote device
-//    private Timer bluetooth_timer = null;
-//    private int bluetooth_timeout=2*1000*60;
-//    private InputStream in=null;
-//    private OutputStream out=null;
-//    private android.bluetooth.BluetoothDevice bluetoothDevice;
-//    private int plen = 0;
-//    private int[] PATIENTINFO_PACKET_HEADER = new int[]{80, 87, 67, 65, 80, 73};  //PWCAPI
-//    private int dataBPPacketSize=10; // BP
-//    private int dataWeightPacketSize=14; // Weight
-//    private Date connectionTime=null;
-//    private SPPAcceptThread mInsecureSPPAcceptThread;
-//
-//    public int getDataPacketLength(){return plen;}
-//
-//    // private BluetoothBroadcastReceiver actionFoundReceiver;
-//    /**
-//     * Constructor. Prepares a new BluetoothSerial session.
-//     * @param handler  A Handler to send messages back to the UI Activity
-//     */
-//    public BluetoothSerialService(Handler handler) {
-//        mAdapter = BluetoothAdapter.getDefaultAdapter();
-//        mState = STATE_NONE;
-//        mHandler = handler;
-//        if (mInsecureSPPAcceptThread != null) {
-//            mInsecureSPPAcceptThread.cancel();
-//            mInsecureSPPAcceptThread = null;
-//        }
-//
-//    }
-//
-//        public synchronized BluetoothDevice getConnectedDevice() {
-//        return bluetoothDevice;
-//    }
-////    public void registerStateChangeReceiver(Context context) {
-////
-////
-////        //nehal
-////        IntentFilter filter = new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-////        // filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
-////        // filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-////        // filter.addAction(BluetoothDevice.ACTION_FOUND);
-////        actionFoundReceiver = new BluetoothBroadcastReceiver();
-////        context.registerReceiver(actionFoundReceiver, filter);
-////    }
-//
-//    /**
-//     * Set the current state of the chat connection
-//     * @param state  An integer defining the current connection state
-//     */
-//    private synchronized void setState(int state) {
-//        if (D) Log.d(TAG, "setState() " + mState + " -> " + state);
-//        mState = state;
-//
-//        // Give the new state to the Handler so the UI Activity can update
-//        mHandler.obtainMessage(BluetoothSerial.MESSAGE_STATE_CHANGE, state, -1).sendToTarget();
-//    }
-//
-//    /**
-//     * Return the current connection state. */
-//    public synchronized int getState() {
-//        return mState;
-//    }
-////
-////    public synchronized BluetoothDevice getConnectedDevice() {
-////        return bluetoothDevice;
-////    }
-//
-//    public synchronized void setStateNone() { // rename disconnect
-//        mState = STATE_NONE;
-//
-//        //send device name.. if device matches, cleanup ...first do logging
-//        if(bluetoothDevice!=null) {
-//            Log.d("AB", "SET STATE NONE for DEVICE " + bluetoothDevice.getName());
-//        }
-//        // devcie ka object bhi null
-//    }
-//
-//
-//
-//    /**
-//     * Start the chat service. Specifically start AcceptThread to begin a
-//     * session in listening (server) mode. Called by the Activity onResume() */
-//    public synchronized void start(BluetoothDevice device) {
-//        if (D) Log.d(TAG, "##################### STARTING SERIAL SERVICE AGAIN ####################");
-//        if(device!=null)
-//            Log.d("AB", "Bluetooh Serial Service START --- device --- " + device.getName());
-////        if (
-////            // this is specifically for the A&D devices for the SPP listener mode
-////                device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-////        ) {
-////            startBluetoothSPPListener(device);
-////        } else {
-//        // Cancel any thread attempting to make a connection
-//        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
-//
-//        // Cancel any thread currently running a connection
-//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
-//
-//        setState(STATE_NONE);
-//
-//        if (
-//            // this is specifically for the A&D devices for the SPP listener mode
-//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-//        ) {
-//            if (mInsecureSPPAcceptThread != null) {
-//                mInsecureSPPAcceptThread.cancel();
-//                mInsecureSPPAcceptThread = null;
-//            }
-//           //  startBluetoothSPPListener(device);
-//            mInsecureSPPAcceptThread = new SPPAcceptThread(device);
-//            mInsecureSPPAcceptThread.start();
-//        }
-//
-//        //       }
-//    }
-//
-//    /**
-//     * This thread runs while listening for incoming connections. It behaves
-//     * like a server-side client. It runs until a connection is accepted
-//     * (or until cancelled).
-//     */
-//    public class SPPAcceptThread extends Thread {
-//        // The local server socket
-//        public /*final*/ BluetoothServerSocket bluetoothSocket;
-//        private String mSocketType;
-//        private boolean keepSPPThreadRunning;
-//       private BluetoothSocket bs;
-//       private BluetoothDevice sppbtDevice;
-//
-//        public SPPAcceptThread(/*boolean secure*/ BluetoothDevice bluetoothDevice) {
-//            sppbtDevice = bluetoothDevice;
-//            Log.d("AB", "SPP Accept thread device" + sppbtDevice);
-//            keepSPPThreadRunning = true;
-////            BluetoothServerSocket tmp = null;
-////            mSocketType = "Insecure"; //secure ? "Secure":"Insecure";
-////            // Create a new listening server socket
-////            try {
-////                mmServerSocket =mAdapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-////            } catch (IOException e) {
-////                Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
-////            }
-////            // mmServerSocket = tmp;
-//        }
-//        public void run() {
-//            try{
-//                Log.d(TAG, "Starting listening mode");
-//                BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-////                stopSPPThread = true;
-//                while(/*true*/ keepSPPThreadRunning) {
-//
-//                    Log.d("AB", "SPP Thread running ----------> ");
-//                    try {
-//                        /* BluetoothServerSocket*/
-//                        bluetoothSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-////                    final BluetoothSocket bs=bluetoothSocket.accept();
-//                        /*final BluetoothSocket*/
-//                        bs = bluetoothSocket.accept();
-//                    }catch (IOException ex){
-//                        Log.d(TAG,"SPP Listener Run: bluetoothSocket" + ex.getMessage());
-//                        Thread.sleep(1000);
-//                        continue;
-//                    }
-//
-//                    if (bs == null) {
-//                        try {
-//                            closeConnection();
-//                        } catch(Exception e) {
-//                            Log.d(TAG,"CLOSE SPP connection---", e);
-//                        }
-//                    }
-//                    bluetoothSocket.close();
-//
-//                    Log.d(TAG, "Incoming bluetooth connection");
-//                    Thread bst = new Thread(new Runnable(){
-//
-//                        @Override
-//                        public void run() {
-//                            try{
-//                                Log.d(TAG, "startBluetoothSPPListener DEVICE : " + sppbtDevice.getName());
-//                                BluetoothDevice btDevice = sppbtDevice; //TODO this global instance changes frequently and this is causing issue
-//                                String deviceType = "";
-//                                try{
-//                                    String deviceAddr = btDevice.getAddress();
-//                                    //found connected device profile, get results
-//                                    Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
-//                                    if (btDevice.getName().contains("UA-767")) {
-//                                        deviceType = "bloodpressure";
-//                                    } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
-//                                        deviceType = "scale";
-//                                    }
-//                                    onConnection(bs);
-//                                    readData(bs, deviceType);
-//                                }
-//                                catch(Exception e){
-//                                    Log.d(TAG,"Error finding bluetooth device" + e);
-//                                }
-//                            }
-//                            catch(Exception e){
-//                                Log.d(TAG,"Bluetooth Socket Error", e);
-//                            }
-//                        }
-//
-//                    });
-//                    bst.start();
-//                }
-//            }
-//            catch(Exception e){
-//                Log.d(TAG,"Bluetooth Listener Error",e);
-//            }
-//
-//        }
-//        public void cancel() {
-//            if (D) Log.d(TAG, "Socket Type" + mSocketType + "cancel " + this);
-//
-//                Log.d("AB", "CANCELNG SPP-----");
-//
-//                keepSPPThreadRunning = true;
-//            try {
-//                Log.d("AB", "1....CANCELNG SPP-----");
-//                if(bs!=null) {
-//                    bs.close();
-//                    bs=null;
-//                }
-//                Log.d("AB", "222...CANCELNG SPP-----");
-//            } catch (IOException e) {
-//                Log.e(TAG, "SPP thread cancel" + bs + "close() of socket failed", e);
-//            }
-////            try{
-////                bluetoothSocket.close();
-////                Log.d("AB", "3....CANCELNG SPP-----");
-////            } catch (IOException e) {
-////                Log.e(TAG, "SPP thread cancel" + bs + "close() of socket failed", e);
-////            }
-//        }
-//    }
-//
-//    private void startBluetoothSPPListener(BluetoothDevice device){
-//        //start the bluetooth listener as its own thread
-//        //this listener checks for all incoming bluetooth connections and invokes the proper class object associated with that device
-//
-//        if(device!=null)
-//            Log.d("AB", "~~~~~~~ Start Bluetooth SPP Listener --- device --- " + device.getName());
-//
-//        Thread adt=new Thread(new Runnable(){
-//            @Override
-//            public void run() {
-//                try{
-//                    Log.d(TAG, "Starting listening mode");
-//                    BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-//                    while(true) {
-//                        BluetoothServerSocket bluetoothSocket=adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-//                        final BluetoothSocket bs=bluetoothSocket.accept();
-//                        if (bs == null) {
-//                            try {
-//                                closeConnection();
-//                            } catch(Exception e) {
-//                                Log.d(TAG,"CLOSE SPP connection---", e);
-//                            }
-//                        }
-//                        bluetoothSocket.close();
-//
-//                        Log.d(TAG, "Incoming bluetooth connection");
-//                        Thread bst = new Thread(new Runnable(){
-//
-//                            @Override
-//                            public void run() {
-//                                try{
-//                                    Log.d(TAG, "startBluetoothSPPListener DEVICE : " + device.getName());
-//                                    BluetoothDevice btDevice = device; //TODO this global instance changes frequently and this is causing issue
-//                                    String deviceType = "";
-//                                    try{
-//                                        String deviceAddr = btDevice.getAddress();
-//                                        //found connected device profile, get results
-//                                        Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
-//                                        if (btDevice.getName().contains("UA-767")) {
-//                                            deviceType = "bloodpressure";
-//                                        } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351") ) {
-//                                            deviceType = "scale";
-//                                        }
-//                                        onConnection(bs);
-//                                        readData(bs, deviceType);
-//                                    }
-//                                    catch(Exception e){
-//                                        Log.d(TAG,"Error finding bluetooth device" + e);
-//                                    }
-//                                }
-//                                catch(Exception e){
-//                                    Log.d(TAG,"Bluetooth Socket Error", e);
-//                                }
-//                            }
-//
-//                        });
-//                        bst.start();
-//                    }
-//                }
-//                catch(Exception e){
-//                    Log.d(TAG,"Bluetooth Listener Error",e);
-//                }
-//            }
-//
-//
-//
-//        });
-//        adt.start();
-//    }
-//
-//    /**
-//     * Start the ConnectThread to initiate a connection to a remote device.
-//     * @param device  The BluetoothDevice to connect
-//     * @param secure Socket Security type - Secure (true) , Insecure (false)
-//     */
-//    public synchronized void connect(BluetoothDevice device, boolean secure) {
-//        if (D) Log.d(TAG, "connect to: " + device);
-//        bluetoothDevice = device;
-//
-//        if(device!=null)
-//            Log.d("AB", "Bluetooh Serial Service CONNECT --- device --- " + device.getName());
-//
-//        // Cancel any thread attempting to make a connection
-//        if (mState == STATE_CONNECTING) {
-//            if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
-//        }
-//
-//        // Cancel any thread currently running a connection
-//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
-//
-//        // Start the thread to connect with the given device
-//        mConnectThread = new ConnectThread(device, secure);
-//        mConnectThread.start();
-//        setState(STATE_CONNECTING);
-//    }
-//
-//    /**
-//     * Start the ConnectedThread to begin managing a Bluetooth connection
-//     * @param socket  The BluetoothSocket on which the connection was made
-//     * @param device  The BluetoothDevice that has been connected
-//     */
-//    public synchronized void connected(BluetoothSocket socket, BluetoothDevice device, final String socketType) {
-//        if (D) Log.d(TAG, "connected, Socket Type:" + socketType);
-//
-//        // Cancel the thread that completed the connection
-//        if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
-//
-//        // Cancel any thread currently running a connection
-//        if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
-//
-//        // Cancel the accept thread because we only want to connect to one device
-//        if (mSecureAcceptThread != null) {
-//            mSecureAcceptThread.cancel();
-//            mSecureAcceptThread = null;
-//        }
-//        if (mInsecureAcceptThread != null) {
-//            mInsecureAcceptThread.cancel();
-//            mInsecureAcceptThread = null;
-//        }
-//
-////        if (mInsecureSPPAcceptThread != null) {
-////            mInsecureSPPAcceptThread.cancel();
-////            mInsecureSPPAcceptThread = null;
-////        }
-//
-//        // Start the thread to manage the connection and perform transmissions
-//        if (
-//            !device.getName().contains("UA-767") &&
-//                !device.getName().contains("UC-355") &&
-//                !device.getName().contains("UC-351")
-//        ) {
-//            mConnectedThread = new ConnectedThread(socket, socketType, device);
-//            mConnectedThread.start();
-//        }
-//
-//        // Send the name of the connected device back to the UI Activity
-//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
-//        Bundle bundle = new Bundle();
-//        bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
-//        msg.setData(bundle);
-//        mHandler.sendMessage(msg);
-//
-//        setState(STATE_CONNECTED);
-//    }
-//
-//
-//
-//    /**
-//     * Stop all threads
-//     */
-//    public synchronized void stop() {
-//        if (D) Log.d(TAG, "stop");
-//
-//        if(bluetoothDevice!=null)
-//            Log.d("AB", "Bluetooh Serial Service STOP --- device --- " + bluetoothDevice.getName());
-//
-//        if (mConnectThread != null) {
-//            mConnectThread.cancel();
-//            mConnectThread = null;
-//        }
-//
-//        if (mConnectedThread != null) {
-//            mConnectedThread.cancel();
-//            mConnectedThread = null;
-//        }
-//
-//        if (mSecureAcceptThread != null) {
-//            mSecureAcceptThread.cancel();
-//            mSecureAcceptThread = null;
-//        }
-//
-//        if (mInsecureAcceptThread != null) {
-//            mInsecureAcceptThread.cancel();
-//            mInsecureAcceptThread = null;
-//        }
-//
-//        if (mInsecureSPPAcceptThread != null) {
-//            mInsecureSPPAcceptThread.cancel();
-//            mInsecureSPPAcceptThread = null;
-//        }
-//
-//        //close our code changes open connections also
-////        try {
-////            closeBluetoothConnection();
-////        } catch (IOException e) {
-////            e.printStackTrace();
-////        }
-////
-////        bst = null;
-////        adt = null;
-//
-//
-//        setState(STATE_NONE);
-//    }
-//
-//    /**
-//     * Write to the ConnectedThread in an unsynchronized manner
-//     * @param out The bytes to write
-//     * @see ConnectedThread#write(byte[])
-//     */
-//    public void write(byte[] out) {
-//        // Create temporary object
-//        ConnectedThread r;
-//        // Synchronize a copy of the ConnectedThread
-//        synchronized (this) {
-//            if (mState != STATE_CONNECTED) return;
-//            r = mConnectedThread;
-//        }
-//        // Perform the write unsynchronized
-//        r.write(out);
-//    }
-//
-//    /**
-//     * Indicate that the connection attempt failed and notify the UI Activity.
-//     */
-//    private void connectionFailed() {
-//        // Send a failure message back to the Activity
-//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-//        Bundle bundle = new Bundle();
-//        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
-//        msg.setData(bundle);
-//        mHandler.sendMessage(msg);
-//
-//        // Start the service over to restart listening mode
-//        Log.d("AB", "Connection Failed Bluetooth serial service RESTART ");
-//        BluetoothSerialService.this.start(null);
-//    }
-//
-//    /**
-//     * Indicate that the connection was lost and notify the UI Activity.
-//     */
-//    private void connectionLost() {
-//        // Send a failure message back to the Activity
-//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-//        Bundle bundle = new Bundle();
-//        bundle.putString(BluetoothSerial.TOAST, "Device connection was lost");
-//        msg.setData(bundle);
-//        mHandler.sendMessage(msg);
-//
-//        // Start the service over to restart listening mode
-//        Log.d("AB", "Connection Lost Bluetooth serial service RESTART ");
-//        BluetoothSerialService.this.start(null);
-//    }
-//
-//    /**
-//     * This thread runs while listening for incoming connections. It behaves
-//     * like a server-side client. It runs until a connection is accepted
-//     * (or until cancelled).
-//     */
-//    private class AcceptThread extends Thread {
-//        // The local server socket
-//        private final BluetoothServerSocket mmServerSocket;
-//        private String mSocketType;
-//
-//        public AcceptThread(boolean secure) {
-//            BluetoothServerSocket tmp = null;
-//            mSocketType = secure ? "Secure":"Insecure";
-//
-//            // Create a new listening server socket
-//            try {
-//                if (secure) {
-//                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);
-//                } else {
-//                    tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
-//                }
-//            } catch (IOException e) {
-//                Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
-//            }
-//            mmServerSocket = tmp;
-//        }
-//
-//        public void run() {
-//            if (D) Log.d(TAG, "Socket Type: " + mSocketType + "BEGIN mAcceptThread" + this);
-//            setName("AcceptThread" + mSocketType);
-//
-//            BluetoothSocket socket;
-//
-//            // Listen to the server socket if we're not connected
-//            while (mState != STATE_CONNECTED) {
-//                try {
-//                    // This is a blocking call and will only return on a
-//                    // successful connection or an exception
-//                    socket = mmServerSocket.accept();
-//                } catch (IOException e) {
-//                    Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
-//                    break;
-//                }
-//
-//                // If a connection was accepted
-//                if (socket != null) {
-//                    synchronized (BluetoothSerialService.this) {
-//                        switch (mState) {
-//                            case STATE_LISTEN:
-//                            case STATE_CONNECTING:
-//                                // Situation normal. Start the connected thread.
-//                                connected(socket, socket.getRemoteDevice(),
-//                                    mSocketType);
-//                                break;
-//                            case STATE_NONE:
-//                            case STATE_CONNECTED:
-//                                // Either not ready or already connected. Terminate new socket.
-//                                try {
-//                                    socket.close();
-//                                } catch (IOException e) {
-//                                    Log.e(TAG, "Could not close unwanted socket", e);
-//                                }
-//                                break;
-//                        }
-//                    }
-//                }
-//            }
-//            if (D) Log.i(TAG, "END mAcceptThread, socket Type: " + mSocketType);
-//
-//        }
-//
-//        public void cancel() {
-//            if (D) Log.d(TAG, "Socket Type" + mSocketType + "cancel " + this);
-//            try {
-//                mmServerSocket.close();
-//            } catch (IOException e) {
-//                Log.e(TAG, "Socket Type" + mSocketType + "close() of server failed", e);
-//            }
-//        }
-//    }
-//
-//
-//    /**
-//     * This thread runs while attempting to make an outgoing connection
-//     * with a device. It runs straight through; the connection either
-//     * succeeds or fails.
-//     */
-//    private class ConnectThread extends Thread {
-//        private /*final*/ BluetoothSocket mmSocket;
-//        private final BluetoothDevice mmDevice;
-//        private String mSocketType;
-//
-//        public ConnectThread(BluetoothDevice device, boolean secure) {
-//            mmDevice = device;
-//            BluetoothSocket tmp = null;
-//            if ( //nehal
-//                device.getName().contains("UA-767") ||
-//                    device.getName().contains("UC-355") ||
-//                    device.getName().contains("UC-351")
-//            ) {
-//                secure = false;
-//            }
-//
-//            mSocketType = secure ? "Secure" : "Insecure";
-//
-//
-//
-////            // Get a BluetoothSocket for a connection with the given BluetoothDevice
-////            if (
-////                !device.getName().contains("UA-767") &&
-////                    !device.getName().contains("UC-355") &&
-////                    !device.getName().contains("UC-351")
-////            ) {
-//                // Get a BluetoothSocket for a connection with the given BluetoothDevice
-//                try {
-//                    if (secure) {
-//                        tmp = device.createRfcommSocketToServiceRecord(UUID_SPP);
-//                    } else {
-//                        tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-//                    }
-//                } catch (IOException e) {
-//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-//                }
-//
-//
-//                // mAdapter.cancelDiscovery();
-////            } else {
-////                try {
-////                    //  mAdapter.cancelDiscovery();
-////                    tmp = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
-////                    //  tmp.connect();
-////                } catch ( NoSuchMethodException e) {
-////                  //  retryConnection();
-////                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-////                } catch (IllegalAccessException e) {
-////                    e.printStackTrace();
-////                } catch (InvocationTargetException e) {
-////                    e.printStackTrace();
-////                }
-////
-////            }
-//            mmSocket = tmp;
-//        }
-//
-//
-//        public void run() {
-//            Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
-//            setName("ConnectThread" + mSocketType);
-//           // BluetoothSocket tmp = mmSocket;
-////            if (
-////                    !mmDevice.getName().contains("UA-767") &&
-////                            !mmDevice.getName().contains("UC-355") &&
-////                            !mmDevice.getName().contains("UC-351")
-////            ) {
-//            // Always cancel discovery because it will slow down a connection
-//          //  mAdapter.cancelDiscovery();
-//
-//            // Make a connection to the BluetoothSocket
-//            try {
-//                // This is a blocking call and will only return on a successful connection or an exception
-//                Log.i(TAG,"Connecting to socket...");
-////                tmp = mmSocket;
-//                mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
-//                mmSocket.connect();
-//                Log.i(TAG,"Connected");
-//            } catch (IOException | NoSuchMethodException e) {
-//                Log.e(TAG, e.toString());
-//
-////                if(mmSocket != null) {
-////                    try {
-////                        mmSocket.close();
-////                    } catch (IOException e1) {
-////                        Log.d("AB", "Closing and null the socket");
-////
-////                        e1.printStackTrace();
-////                    }
-////                    mmSocket = null;
-////                }
-//                // Some 4.1 devices have problems, try an alternative way to connect
-//                // See https://github.com/don/BluetoothSerial/issues/89
-//                    try {
-//                            if (mSocketType.equalsIgnoreCase("Secure")) {
-//                                mmSocket = mmDevice.createRfcommSocketToServiceRecord(UUID_SPP);
-//                            } else {
-//                                mmSocket = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-//                            }
-//                        Log.i(TAG,"Trying fallback...");
-////                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[] {int.class}).invoke(mmDevice,1);
-//                        mmSocket.connect();
-//                        Log.i(TAG,"Connected");
-//                    } catch (Exception e2) {
-//                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-//
-//
-//                                        try {
-//                                            mmSocket.close();
-//                                            closeConnection();
-//                                        } catch (IOException e3) {
-//                                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-//                                        }
-////                        if (
-////                            !mmDevice.getName().contains("UA-767") &&
-////                                !mmDevice.getName().contains("UC-355") &&
-////                                !mmDevice.getName().contains("UC-351")
-////                        ) {
-//                                        connectionFailed();
-//
-//
-//                    //    }
-//                    //    }
-//                        return;
-//                    }
-//          //      }
-//            } catch (IllegalAccessException e) {
-//                e.printStackTrace();
-//            }
-//            catch (InvocationTargetException e) {
-//                e.printStackTrace();
-//            }
-//
-//            // Reset the ConnectThread because we're done
-//            synchronized (BluetoothSerialService.this) {
-//                mConnectThread = null;
-//            }
-//
-//            // Start the connected thread
-//            connected(mmSocket, mmDevice, mSocketType);
-//        }
-//
-//        public void cancel() {
-//            try {
-//                mmSocket.close();
-//            } catch (IOException e) {
-//                Log.e(TAG, "close() of connect " + mSocketType + " socket failed", e);
-//            }
-//        }
-//
-//        private void retryConnection() {
-////            JSONArray deviceList = new JSONArray();
-////            Set<BluetoothDevice> bondedDevices = mAdapter.getBondedDevices();
-////            if(bondedDevices.contains(mmDevice)) {
-////                Log.d("AB", mmDevice.getName() + " is bonded so not retrying it ");
-////            } else {
-//
-//            Log.d("AB", mmDevice.getName() + "  retrying it ");
-//
-//
-//            try {
-//                Log.i(TAG, "111 Trying fallback...");
-////                    mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
-////                    mmSocket.connect();
-//                mmSocket = mmDevice.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-//                mmSocket.connect();
-//                Log.i(TAG, "Connected");
-//            } catch (Exception e2) {
-//                Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-//
-//
-//                try {
-//                    mmSocket.close();
-//                    closeConnection();
-//                } catch (IOException e3) {
-//                    Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-//                }
-//                Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-//                Bundle bundle = new Bundle();
-//                bundle.putString(BluetoothSerial.TOAST, "MMMM Unable to connect to device");
-//                msg.setData(bundle);
-//                mHandler.sendMessage(msg);
-//            }
-//            //      }
-//        }
-//
-//    }
-//
-//    private void connectToDevice(BluetoothSocket socket) throws IOException {
-//        mmSocket = socket;
-//        bluetoothDevice = socket.getRemoteDevice();
-//        if(bluetoothDevice!=null)
-//            Log.d("AB", "Service -- Connect To Device ---- " + bluetoothDevice.getName());
-//        Log.d(TAG, "bluetoothDevice CONNECTED OR NOT: " + socket.isConnected());
-//        in = socket.getInputStream();
-//        out = socket.getOutputStream();
-//        Log.d(TAG, "out: " + out);
-//    }
-//
-//    private void readPatientInfoPacket() throws IOException{
-//        // Check the packet type...
-//        int pktType1 = in.read();
-//        int pktType2 = in.read();
-//        int pktType = pktType1 + shift(pktType2,8);
-//        Log.d(TAG,"packet type: " + pktType);
-//
-//
-//        //if packet type is not the data packet, then read in and discard header packet
-//        if (pktType != 2) {
-//            Log.d(TAG,"skipping patient info packet...");
-//            //this is a patient info packet, skip the next 28 bytes
-//            boolean packetend = false;
-//            int lookfor = 0;
-//            while (!packetend) {
-//                int b = in.read();
-//                if (b == PATIENTINFO_PACKET_HEADER[lookfor]) {
-//                    lookfor++;
-//                }
-//                else if (lookfor > 0) {
-//                    lookfor = 0;
-//                }
-//
-//                if (lookfor == PATIENTINFO_PACKET_HEADER.length) {
-//                    packetend = true;
-//                }
-//            }
-//            Log.d(TAG,"end of patient info packet found...");
-//
-//            //now start the packet read over again
-//            pktType1 = in.read();
-//            pktType2 = in.read();
-//            pktType = pktType1 + shift(pktType2,8);
-//
-//        }
-//    }
-//
-//    public static int shift(int val, int shift){
-//        return (val << shift);
-//    }
-//
-//    private void readPatientPacket() throws IOException{
-//        // Check the packet length...
-//        plen = in.read() + shift(in.read(),8) + shift(in.read(),16) + shift(in.read(),24);
-//        Log.d(TAG,"packet len: " + plen);
-//
-//        //read devtype
-//        int devType = in.read() + shift(in.read(),8);
-//        Log.d(TAG,"devtype: " + devType);
-//// transmittingDeviceName = devType;
-//        //get flag
-//        int flag = in.read();
-//        Log.d(TAG,"flag: " + flag);
-//
-//        //get time of measurement
-//        int myear = in.read() + shift(in.read(),8);
-//        int mmonth = in.read();
-//        int mday = in.read();
-//        int mhour = in.read();
-//        int mmin = in.read();
-//        int msec = in.read();
-//        Log.d(TAG,"measurement time: " + mday + "/" + mmonth + "/" + myear + " " + mmin + ":" + msec);
-//
-//        //get time of transmission
-//        int tyear = in.read() + shift(in.read(),8);
-//        int tmonth = in.read();
-//        int tday = in.read();
-//        int thour = in.read();
-//        int tmin = in.read();
-//        int tsec = in.read();
-//        Log.d(TAG,"transmission time: " + tday + "/" + tmonth + "/" + tyear + " " + tmin + ":" + tsec);
-//
-//        Date measurementDate=new Date();
-//        Date transmissionDate=(Date)measurementDate.clone();
-//        measurementDate.setYear(myear-1900);
-//        measurementDate.setMonth(mmonth-1);
-//        measurementDate.setDate(mday);
-//        measurementDate.setHours(mhour);
-//        measurementDate.setMinutes(mmin);
-//        measurementDate.setSeconds(msec);
-//        transmissionDate.setYear(tyear-1900);
-//        transmissionDate.setMonth(tmonth-1);
-//        transmissionDate.setDate(tday);
-//        transmissionDate.setHours(thour);
-//        transmissionDate.setMinutes(tmin);
-//        transmissionDate.setSeconds(tsec);
-//
-//        //get bluetooth id of device
-//        int id0 = in.read();
-//        int id1 = in.read();
-//        int id2 = in.read();
-//        int id3 = in.read();
-//        int id4 = in.read();
-//        int id5 = in.read();
-//        Log.d(TAG,"bluetooth id: " + id0 + ":" + id1 + ":" + id2 + ":" + id3 + ":" + id4 + ":" + id5);
-//
-//        //get device name and serial number
-//        String devnameupper = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//
-//
-//        String devserial = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//        String devnamelower = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//
-////        Log.d("AB", "Dev name upper "+ devnameupper);
-////        Log.d("AB", "Dev serial number "+ devserial);
-// //       Log.d("AB", "Dev name lower "+ devnamelower);
-//
-//        //device battery status
-//        int batterystatus = in.read();
-//        Log.d(TAG,"battery status: " + batterystatus);
-//
-//        //skip reserved byte
-//        in.skip(1);
-//
-//        //get device firmware/hardware
-//        int devfirmwarehardware = in.read();
-//    }
-////private int transmittingDeviceName ;
-//
-//    public void onConnection(BluetoothSocket socket) throws IOException {
-//        Log.d(TAG, "onConnection" + socket);
-//        connectionTime = new Date();
-//        if (socket!=null) {
-//            in = socket.getInputStream();
-//            out = socket.getOutputStream();
-//            restartBluetoothTimeout(socket);
-//        }
-//    }
-//
-//    private void readData(BluetoothSocket socket, String deviceType) throws IOException{
-//        connectToDevice(socket);
-//        readPatientInfoPacket();
-//        readPatientPacket();
-//       // Log.d("AB", "transmittingDeviceName" + transmittingDeviceName);
-//      //  Log.d("AB", "deviceType" + deviceType);
-////        if(transmittingDeviceName== 767 || transmittingDeviceName ==766  ) {
-////            onBPDataPacket();
-////        }else if ( transmittingDeviceName== 355 || transmittingDeviceName== 351 || transmittingDeviceName ==322 /* 322*/ ) {
-////            onScaleDataPacket();
-////        } else {
-//            if (deviceType == "bloodpressure") {
-//                onBPDataPacket();
-//            } else {
-//                onScaleDataPacket();
-//            }
-//     //   }
-//        sendAcknowledgement();
-//        closeConnection();
-//    }
-//
-//    //bluetooth socket timeout functions
-//    protected void startBluetoothTimeout(BluetoothSocket socket){
-//        bluetooth_timer=new Timer();
-//        bluetooth_timer.schedule(new TimerTask() {
-//            @Override
-//            public void run() {
-//                //shut down the bluetooth socket
-//                Log.d(TAG,"bluetooth socket timeout...");
-//                try {
-//                    socket.close();
-//                } catch(Exception e) {}
-//            }
-//        }, bluetooth_timeout);
-//    }
-//    protected void cancelBluetoothTimeout(){
-//        try{
-//            bluetooth_timer.cancel();
-//            //nehal
-//            // setState(STATE_NONE);
-//        }
-//        catch(Exception e){}
-//    }
-//    protected void restartBluetoothTimeout(BluetoothSocket socket){
-//        cancelBluetoothTimeout();
-//        startBluetoothTimeout(socket);
-//    }
-//
-//    /**
-//     * This thread runs during a connection with a remote device.
-//     * It handles all incoming and outgoing transmissions.
-//     */
-//    private class ConnectedThread extends Thread {
-//        private final BluetoothSocket mmSocket;
-//        private final InputStream mmInStream;
-//        private final OutputStream mmOutStream;
-//        BluetoothDevice btDevice;
-//
-//        public ConnectedThread(BluetoothSocket socket, String socketType, BluetoothDevice device) {
-//            Log.d(TAG, "create ConnectedThread: " + socketType);
-//            btDevice = device;
-//            mmSocket = socket;
-//            InputStream tmpIn = null;
-//            OutputStream tmpOut = null;
-//
-//            // Get the BluetoothSocket input and output streams
-//            try {
-//                tmpIn = socket.getInputStream();
-//                tmpOut = socket.getOutputStream();
-//            } catch (IOException e) {
-//                Log.e(TAG, "temp sockets not created", e);
-//            }
-//
-//            mmInStream = tmpIn;
-//            mmOutStream = tmpOut;
-//        }
-//
-//        public void run() {
-//            Log.d(TAG, "ConnectedThread reading bytes");
-//            byte[] buffer = new byte[1024];
-//            int bytes;
-//
-//            // Keep listening to the InputStream while connected
-//            while (true) {
-//                try {
-//                    // Read from the InputStream
-//                    bytes = mmInStream.read(buffer);
-//                    String data = new String(buffer, 0, bytes);
-//
-//                    // Send the new data String to the UI Activity
-//                    mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ, data).sendToTarget();
-//
-//                    // Send the raw bytestream to the UI Activity.
-//                    // We make a copy because the full array can have extra data at the end
-//                    // when / if we read less than its size.
-//                    if (bytes > 0) {
-//                        byte[] rawdata = Arrays.copyOf(buffer, bytes);
-//                        mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ_RAW, rawdata).sendToTarget();
-//                    }
-//
-//                } catch (IOException e) {
-//                    Log.e(TAG, "disconnected", e);
-//                    connectionLost();
-//                    if(btDevice!=null)
-//                        Log.d("AB", "Connected Thread DISCONNECTED --- restarting Bluetooth service for device " + btDevice);
-//                    // Start the service over to restart listening mode
-//                    BluetoothSerialService.this.start(btDevice);
-//                    break;
-//                }
-//            }
-//        }
-//
-//        /**
-//         * Write to the connected OutStream.
-//         * @param buffer  The bytes to write
-//         */
-//        public void write(byte[] buffer) {
-//            try {
-//                mmOutStream.write(buffer);
-//
-//                // Share the sent message back to the UI Activity
-//                mHandler.obtainMessage(BluetoothSerial.MESSAGE_WRITE, -1, -1, buffer).sendToTarget();
-//
-//            } catch (IOException e) {
-//                Log.e(TAG, "Exception during write", e);
-//            }
-//        }
-//
-//        public void cancel() {
-//            try {
-//                mmSocket.close();
-//            } catch (IOException e) {
-//                Log.e(TAG, "close() of connect socket failed", e);
-//            }
-//        }
-//    }
-//
-//    public void onScaleDataPacket() throws IOException {
-//        //now get the scale data packet information
-//        int i = 0;
-//        String datastr = "";
-//        while (i < dataWeightPacketSize) {
-//            datastr = datastr + (char) in.read();
-//            i++;
-//        }
-//        Log.d(TAG,"scale data: " + datastr);
-//
-//        //if the reported length was more than 14, skip the rest of the data
-//        if (getDataPacketLength() > dataWeightPacketSize) {
-//            in.skip(getDataPacketLength() - dataWeightPacketSize);
-//        }
-//
-//        //parse reading
-//        double w = 0;
-//        String readingval = datastr.substring(4, 10);
-//        String readingtype = datastr.substring(10, 12);
-//        Log.d(TAG,"parsing: " + readingval);
-//        Log.d(TAG,"reading type: " + readingtype);
-//        //force lb as reading type
-//        if (readingtype.equals("lb")) {
-//            w = Double.valueOf(readingval);
-//            Log.d(TAG, "weight weight" + w);
-//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
-//            msg.obj = w;
-//            mHandler.sendMessage(msg);
-//        } else if (readingtype.equals("kg")){
-//            //convert kg to lbs
-//            w = Double.valueOf(readingval);
-//            w = kgTolbs(w);
-//            Log.d(TAG,"converted to lbs: " + w);
-//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
-//            msg.obj = w;
-//            mHandler.sendMessage(msg);
-//        }
-//
-//    }
-//
-//    //functions
-//    public static double kgTolbs(double kg){
-//        kg = kg * 2.20462;
-//        int kgi = (int)(kg*10);
-//        double lbs = (double)kgi/10.0;
-//        return lbs;
-//    }
-//
-//    public void onBPDataPacket() throws IOException {
-//        int i = 0;
-//        String datastr = "";
-//        while (i < dataBPPacketSize) {
-//            datastr = datastr + (char) in.read();
-//            i++;
-//        }
-//
-//        Log.d(TAG,"Datastring for blood pressure packet " + datastr);
-//
-//        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ);
-//        msg.obj = datastr;
-//        mHandler.sendMessage(msg);
-//    }
-//
-//    private void sendAcknowledgement(){
-//        //now send response to acknowledge
-//        try{
-//            String msg = "PWA1";
-//            byte[] send = msg.getBytes();
-//            out.write(send);
-//            out.flush();
-//        }
-//        catch(Exception e){e.printStackTrace();}
-//    }
-//
-//    private void closeConnection() throws IOException{
-//        closeBluetoothConnection();
-//    }
-//
-//    protected void closeBluetoothConnection() throws IOException {
-//        try {
-//            in.close();
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-//        try {
-//            out.close();
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-////        if (mmSocket != null) {
-////            try {
-////                mmSocket.close();
-////            } catch (IOException e) {
-////                e.printStackTrace();
-////            }
-////            mmSocket = null;
-////        }
-//        // try{mmSocket.close();}catch(Exception e){e.printStackTrace();}
-//        cancelBluetoothTimeout();
-//        //nehal
-//        setState(STATE_NONE);
-//        if (bluetoothDevice != null)
-//            Log.d("AB", "Closing BT connectionss " + bluetoothDevice.getName());
-//        // bluetoothDevice = null;
-//    }
-//}
-//
-//// issues remaining ..
-////intermingling of data,...check data packet receievd
-////test with multiple devices and ble also
-//


### PR DESCRIPTION
**Summary of Changes done :-**

Though the polling from ionic layer tries to connect Bluetooth Serial service continuously very frequently, at the plugin native layer, we have maintained a structure similar to Queue in which :

- There is a structure <ClassicDevice> which comprises of bluetoothDevice (for which polling happened), plugin callback , secure param

- as soon as a connect request comes, if the queue is empty, connect happens with the supplied ClassicDevice

- if anything is under process, item is added to queue

- as soon as we get notification from the earlier connect operation, we take out an element from the queue and process it iteratively

- SPP listener is a thread, which is checked every time whether it is alive when we make a new connection request and if it is alive, we try to connect and listen to the bluetooth socket. If it is not alive, we cancel the thread and create a new instance accordingly.e

- We are also listening to ACL disconnect and such similar notifications for processing

As SPP listener is an independent from the Bluetooth service connection to a particular device, some cross reading issues were observed and we have tried to fix them by the following:

- earlier connect() method callback from plugin did not supply which device instance it connected to, we have added that implementation. This will ensure the further processing at ionic layer will be done based on what actually device the socket got connected to.

- while reading the data packets, we have inferred the device type by the devType field and not by the device type which we have maintained(as this keeps on changing very frequently)

- as the weight / bp services have directly subscribed for the data irrespective of the device, at the last point when we get the data, as per the data length obtained, we have added checks on ionic layer)