### PR TITLE
Cleanup of parsing and BT serial connection optimisation

### DIFF
--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -370,9 +370,9 @@ public class BluetoothSerial extends CordovaPlugin {
         public static boolean isSupported(BluetoothDevice device) {
             if(device!=null) {
                 String text = device.getName();
-                Log.d(TAG, "IS SPP PROFILE DEVICE text ---> " + text);
+
                 for (SPPProfileDevice b : SPPProfileDevice.values()) {
-                    Log.d(TAG, "IS SPP PROFILE DEVICE b.text ---> " + b.text);
+
                     if (text != null && text.indexOf(b.text) > 0) {
                         Log.d(TAG, "IS SPP PROFILE DEVICE ---> " + b.text);
                         return true;
@@ -386,10 +386,7 @@ public class BluetoothSerial extends CordovaPlugin {
     private /*synchronized*/ void disconnect(CallbackContext callbackContext) {
         Log.d(TAG, "## Disconnect event making connect callback null");
         connectCallback = null;
-//        BluetoothDevice connectedDevice = bluetoothSerialService.getConnectedDevice();
-//        queuedClassicDevices.remove(connectedDevice);
-      //  queuedClassicDevices.clear();
-      //  Log.d(TAG, "CLEARING the QUEUE");
+
         bluetoothSerialService.stop();
 
         callbackContext.success();
@@ -699,10 +696,10 @@ public class BluetoothSerial extends CordovaPlugin {
                     break;
                 case MESSAGE_READ_RAW:
                     Log.d(TAG, "Read RAW message now sending to subscriber " + rawDataAvailableCallback);
+
                     if (rawDataAvailableCallback != null) {  Log.d(TAG, "Read RAW message now definitely sending to subscriber ");
                         byte[] bytes = (byte[]) msg.obj;
                         sendRawDataToSubscriber(bytes);
-
                     }
                     break;
                 case MESSAGE_STATE_CHANGE:

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -221,7 +221,7 @@ public class BluetoothSerial extends CordovaPlugin {
             connect(args, secure, callbackContext);
 
         } else if (action.equals(DISCONNECT)) {
-            Log.d(TAG, "Calling disconnect ---<><> commented for now! ");
+
             disconnect(callbackContext);
 
         } else if (action.equals(WRITE)) {
@@ -384,15 +384,11 @@ public class BluetoothSerial extends CordovaPlugin {
     }
 
     private /*synchronized*/ void disconnect(CallbackContext callbackContext) {
-        Log.d(TAG, "## Disconnect event making connect callback null");
         connectCallback = null;
-
         bluetoothSerialService.stop();
-
         callbackContext.success();
-
-
     }
+
     private boolean hasBluetoothPermissions() {
         if (Build.VERSION.SDK_INT >= 31) { // for android 12 check for Nearby devices permission
             return cordova.hasPermission(BLUETOOTH_SCAN) && cordova.hasPermission(BLUETOOTH_CONNECT);
@@ -587,8 +583,6 @@ public class BluetoothSerial extends CordovaPlugin {
         Log.d(TAG, "## Processing incoming connect for device " + device.getName());
         Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
 
-       // connectClassic(device, secure, callbackContext); nehal
-
         synchronized (queuedClassicDevices) {
             if(!bondedDevices.contains(device)) {
                 Log.d(TAG, "This is a device which has requested to pair --- ");
@@ -628,7 +622,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
     private void addToQueue(ClassicDevice upcomingDevice) {
         if (queuedClassicDevices!=null) {
-            if (!queuedClassicDevices.contains(upcomingDevice)) { //new cleanup possibility-> TODO if already connected device is requesting to be added, dont add that
+            if (!queuedClassicDevices.contains(upcomingDevice)) {
                 queuedClassicDevices.add(upcomingDevice);
                 Log.d(TAG, "## Added to queue ");
                 Log.d(TAG, "## Queue size ## " + queuedClassicDevices.size());
@@ -648,13 +642,13 @@ public class BluetoothSerial extends CordovaPlugin {
     }
 
     private synchronized void connectClassic(BluetoothDevice device, boolean secure, CallbackContext callbackContext) {
-      //  executeQueueHandler();
+
         Log.d(TAG, "## Connect to classic " + device.getName());
         if (device != null) {
 
             connectCallback = callbackContext;
             //Based on device, we need to either call Start or Connect
-            if(/*isSPPListenerNeeded(device)*/ SPPProfileDevice.isSupported(device)) { //For devices which need SPP Listener
+            if(SPPProfileDevice.isSupported(device)) { //For devices which need SPP Listener, we only start Accept thread, call connect only for pairing purpose
                 bluetoothSerialService.start(device);
                 Set<BluetoothDevice> bondedDevices = bluetoothAdapter.getBondedDevices();
                 if(!bondedDevices.contains(device)) { // Connect only for pairing
@@ -767,7 +761,7 @@ public class BluetoothSerial extends CordovaPlugin {
     }
 
     private void notifyConnectionSuccess() {
-        Log.d(TAG, "Notofy connection success to pluginn ---->> " + connectCallback);
+        Log.d(TAG, "Notify connection success to plugin ---->> " + connectCallback);
         if (connectCallback != null) {
 
             BluetoothDevice connectedDevice;

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -182,6 +182,10 @@ public class BluetoothSerial extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView){
         Log.d(TAG, "Initialize plugin & queue");
+        if(queuedClassicDevices!=null) {
+            queuedClassicDevices.clear();
+            Log.d(TAG, "Clearing the queue");
+        }
     }
 
     @Override
@@ -218,7 +222,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
         } else if (action.equals(DISCONNECT)) {
             Log.d(TAG, "Calling disconnect ---<><> commented for now! ");
-          //  disconnect(callbackContext);
+            disconnect(callbackContext);
 
         } else if (action.equals(WRITE)) {
 
@@ -382,8 +386,14 @@ public class BluetoothSerial extends CordovaPlugin {
     private /*synchronized*/ void disconnect(CallbackContext callbackContext) {
         Log.d(TAG, "## Disconnect event making connect callback null");
         connectCallback = null;
+//        BluetoothDevice connectedDevice = bluetoothSerialService.getConnectedDevice();
+//        queuedClassicDevices.remove(connectedDevice);
+      //  queuedClassicDevices.clear();
+      //  Log.d(TAG, "CLEARING the QUEUE");
         bluetoothSerialService.stop();
+
         callbackContext.success();
+
 
     }
     private boolean hasBluetoothPermissions() {
@@ -621,7 +631,7 @@ public class BluetoothSerial extends CordovaPlugin {
 
     private void addToQueue(ClassicDevice upcomingDevice) {
         if (queuedClassicDevices!=null) {
-            if (!queuedClassicDevices.contains(upcomingDevice)) {
+            if (!queuedClassicDevices.contains(upcomingDevice)) { //new cleanup possibility-> TODO if already connected device is requesting to be added, dont add that
                 queuedClassicDevices.add(upcomingDevice);
                 Log.d(TAG, "## Added to queue ");
                 Log.d(TAG, "## Queue size ## " + queuedClassicDevices.size());
@@ -760,6 +770,7 @@ public class BluetoothSerial extends CordovaPlugin {
     }
 
     private void notifyConnectionSuccess() {
+        Log.d(TAG, "Notofy connection success to pluginn ---->> " + connectCallback);
         if (connectCallback != null) {
 
             BluetoothDevice connectedDevice;

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -19,6 +19,7 @@ import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
 
@@ -319,15 +320,49 @@ public class BluetoothSerialService {
 //                !device.getName().contains("UC-355") &&
 //                !device.getName().contains("UC-351")
 //        ) {
-            mConnectedThread = new ConnectedThread(socket, socketType, device);
-            mConnectedThread.start();
+        //TODO add 500 ms sleep to check that null subscriber issue in case of stored readings
 
-            // Send the name of the connected device back to the UI Activity
-            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
-            Bundle bundle = new Bundle();
-            bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
-            msg.setData(bundle);
-            mHandler.sendMessage(msg);
+//                    try {
+//                        Log.d(TAG, "Sleeping this thread for  a while ------- " +this);
+//                        Thread.sleep(500);
+//                      //  sleep(500);
+//                    } catch (InterruptedException e) {
+//                        e.printStackTrace();
+//                    }
+
+        /// handler me call -- 1 sec or 500 ms
+        Log.d(TAG, "Connected device --> " + device.getName());
+        mConnectedThread = new ConnectedThread(socket, socketType, device);
+        Handler handler=new Handler(Looper.getMainLooper());
+        Runnable r=new Runnable() {
+            public void run() {
+                Log.d(TAG, "CALLING TO Start connected thread after sleep 1 seconds " + this);
+                //what ever you do here will be done after 3 seconds delay.
+
+                mConnectedThread.start();
+
+
+            }
+        };
+        handler.postDelayed(r, 1000);
+
+        // Send the name of the connected device back to the UI Activity
+        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
+        Bundle bundle = new Bundle();
+        bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
+        msg.setData(bundle);
+        mHandler.sendMessage(msg);
+
+
+//            mConnectedThread = new ConnectedThread(socket, socketType, device);
+//            mConnectedThread.start();
+//
+//            // Send the name of the connected device back to the UI Activity
+//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
+//            Bundle bundle = new Bundle();
+//            bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
+//            msg.setData(bundle);
+//            mHandler.sendMessage(msg);
 
   //     }
   //    setState(STATE_CONNECTED); //TODO COMMENTED code to be reverted
@@ -454,12 +489,13 @@ public class BluetoothSerialService {
                 try {
                     // This is a blocking call and will only return on a
                     // successful connection or an exception
+                    Log.d(TAG, "Trying to connect via Accept thread --->>" );
                     socket = mmServerSocket.accept();
                 } catch (IOException e) {
                     Log.e(TAG, "Socket Type: " + mSocketType + "accept() failed", e);
                     break;
                 }
-
+                Log.d(TAG, "Acccept thread -- connection was accepted --->> state "+mState );
                 // If a connection was accepted
                 if (socket != null) {
                     synchronized (BluetoothSerialService.this) {
@@ -864,6 +900,7 @@ public class BluetoothSerialService {
 //                    } catch (InterruptedException e) {
 //                        e.printStackTrace();
 //                    }
+
 
                     bytes = mmInStream.read(buffer);
                     String data = new String(buffer, 0, bytes);

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -201,8 +201,9 @@ public class BluetoothSerialService {
         Handler handler=new Handler(Looper.getMainLooper());
         Runnable r=new Runnable() {
             public void run() {
-
-                mConnectedThread.start();
+                if (mConnectedThread != null) {
+                    mConnectedThread.start();
+                }
             }
         };
         handler.postDelayed(r, 1000);

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -860,7 +860,7 @@ public class BluetoothSerialService {
                     // Read from the InputStream
 //                    try {
 //                        Log.d(TAG, "Sleeping this thread for  a while " + this);
-//                        sleep(10000);
+//                        sleep(5000);
 //                    } catch (InterruptedException e) {
 //                        e.printStackTrace();
 //                    }

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -132,41 +132,21 @@ public class BluetoothSerialService {
     public synchronized void start(BluetoothDevice device) {
         if (D) Log.d(TAG, "start");
 
-//        if (
-//            // this is specifically for the A&D devices for the SPP listener mode
-//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-//        ) {
-//            resetConnectedBTDevice();
-//
-//            if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
-//                Log.d(TAG, "## SPP thread is alive!!!");
-//                sppAcceptThread.resetDevice(device);
-//            } else {
-//                Log.d(TAG, "## New SPP thread !!!");
-//                sppAcceptThread = new SPPAcceptThread(device);
-//                sppAcceptThread.start();
-//            }
-//        }
-
         // Cancel any thread attempting to make a connection
         if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
 
         // Cancel any thread currently running a connection
         if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
 
-      //  setState(STATE_NONE);
 
-
-        //        // Start the thread to listen on a BluetoothServerSocket
-//        if (mSecureAcceptThread == null) {
-//            mSecureAcceptThread = new AcceptThread(true);
-//            mSecureAcceptThread.start();
-//        }
-        if (mInsecureAcceptThread == null) {
-            mInsecureAcceptThread = new AcceptThread(false);
-            mInsecureAcceptThread.start();
-
+        if(BluetoothSerial.SPPProfileDevice.isSupported(device)){
+            Log.d(TAG, "Creating Accept thread for SPP Profile Device");
+            if (mInsecureAcceptThread == null) {
+                mInsecureAcceptThread = new AcceptThread(false);
+                mInsecureAcceptThread.start();
+            }
         }
+
         setState(STATE_LISTEN);
 
     }
@@ -175,93 +155,6 @@ public class BluetoothSerialService {
         setState(STATE_NONE);
     }
 
-//    private class SPPAcceptThread extends Thread {
-//        private BluetoothServerSocket mmServerSocket;
-//        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-//        BluetoothDevice device;
-//
-//        public void resetDevice(BluetoothDevice device) {
-//            Log.d(TAG, "## Resetting the device from " +  this.device.getName());
-//            this.device = device;
-//            Log.d(TAG, "## Resetting the device to " + device.getName());
-//        }
-//
-//        public SPPAcceptThread(BluetoothDevice device) {
-//            mmServerSocket = null;
-//            this.device = device;
-//            Log.d(TAG, "New SPP Accept thread for device " + device.getName());
-//        }
-//
-//        public void run() {
-//            BluetoothSocket socket = null;
-//            // Keep listening until exception occurs or a socket is returned
-//            try {
-//                Log.i(TAG, "getting socket from adapter");
-//                mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-//
-//
-//                while (true/* mState != STATE_CONNECTED*/) {
-//                    try {
-//                        Log.d(TAG, "----- > SPP accept thread ---> ");
-//
-//                        socket = mmServerSocket.accept();
-//                    } catch (IOException e) {
-//                        Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
-//                    }
-//
-//                    // If a connection was accepted
-//                    if (socket != null) {
-//                        //synchronized (BluetoothSerialService.this) {
-//                        // Do work to manage the connection (in a separate thread)
-//                        try {
-//                            Log.d(TAG, " -- > SPP thread --> connection accepted -- > ");
-//                            BluetoothDevice btDevice = this.device; //device;
-//                            String deviceType = "";
-//                            try {
-//                                String deviceAddr = btDevice.getAddress();
-//                                //found connected device profile, get results
-//                                Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
-//                                if (btDevice.getName().contains("UA-767")) {
-//                                    deviceType = "bloodpressure";
-//                                } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351")) {
-//                                    deviceType = "scale";
-//                                }
-//                                onConnection(socket);
-//                                readData(socket, deviceType);
-//                            } catch (Exception e) {
-//                                Log.d(TAG, "Error finding bluetooth device" + e);
-//                            }
-//                        } catch (Exception e) {
-//                            Log.d(TAG, "Bluetooth Socket Error", e);
-//                        }
-//                        try {
-//                            if(mmServerSocket!=null) {
-//                                mmServerSocket.close();
-//                            }
-//                        } catch (IOException exception) {
-//                            exception.printStackTrace();
-//                        }  //nehal trail
-//                        break;
-//                    }
-//
-//                }
-//
-//
-//            }
-//            catch (IOException ex) {
-//                Log.e(TAG, "error while initializing");
-//            }
-//        }
-//
-//        /** Will cancel the listening socket, and cause the thread to finish */
-//        public void cancel() {
-//            try {
-//                if(mmServerSocket!=null) {
-//                    mmServerSocket.close();
-//                }
-//            } catch (IOException e) { }
-//        }
-//    }
 
     /**
      * Start the ConnectThread to initiate a connection to a remote device.
@@ -313,35 +206,13 @@ public class BluetoothSerialService {
             mInsecureAcceptThread = null;
         }
 
-
-        // Start the thread to manage the connection and perform transmissions
-//        if (
-//            !device.getName().contains("UA-767") &&
-//                !device.getName().contains("UC-355") &&
-//                !device.getName().contains("UC-351")
-//        ) {
-        //TODO add 500 ms sleep to check that null subscriber issue in case of stored readings
-
-//                    try {
-//                        Log.d(TAG, "Sleeping this thread for  a while ------- " +this);
-//                        Thread.sleep(500);
-//                      //  sleep(500);
-//                    } catch (InterruptedException e) {
-//                        e.printStackTrace();
-//                    }
-
-        /// handler me call -- 1 sec or 500 ms
-        Log.d(TAG, "Connected device --> " + device.getName());
         mConnectedThread = new ConnectedThread(socket, socketType, device);
         Handler handler=new Handler(Looper.getMainLooper());
         Runnable r=new Runnable() {
             public void run() {
                 Log.d(TAG, "CALLING TO Start connected thread after sleep 1 seconds " + this);
-                //what ever you do here will be done after 3 seconds delay.
 
                 mConnectedThread.start();
-
-
             }
         };
         handler.postDelayed(r, 1000);
@@ -353,18 +224,6 @@ public class BluetoothSerialService {
         msg.setData(bundle);
         mHandler.sendMessage(msg);
 
-
-//            mConnectedThread = new ConnectedThread(socket, socketType, device);
-//            mConnectedThread.start();
-//
-//            // Send the name of the connected device back to the UI Activity
-//            Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_DEVICE_NAME);
-//            Bundle bundle = new Bundle();
-//            bundle.putString(BluetoothSerial.DEVICE_NAME, device.getName());
-//            msg.setData(bundle);
-//            mHandler.sendMessage(msg);
-
-  //     }
   //    setState(STATE_CONNECTED); //TODO COMMENTED code to be reverted
 
     }
@@ -461,14 +320,14 @@ public class BluetoothSerialService {
             BluetoothServerSocket tmp = null;
             mSocketType = secure ? "Secure":"Insecure";
             Log.d(TAG, "Accept thread" + mSocketType);
-//            // Create a new listening server socket
-            /// this should work based on device type TBD
+
             try {
 //                if (secure) {
 //                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);
 //                } else {
 //                    tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
 //                }
+
                 tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
             } catch (IOException e) {
                 Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
@@ -560,13 +419,9 @@ public class BluetoothSerialService {
             }
 
             // Get a BluetoothSocket for a connection with the given BluetoothDevice
-//            if (
-//                !device.getName().contains("UA-767") &&
-//                    !device.getName().contains("UC-355") &&
-//                    !device.getName().contains("UC-351")
-//            ) {
+
                 Log.d(TAG, "Creating Socket connection 111 ");
-                // Get a BluetoothSocket for a connection with the given BluetoothDevice
+
                 try {
 //                    if (secure) {
 //                        tmp = device.createRfcommSocketToServiceRecord(UUID_SPP);
@@ -577,26 +432,13 @@ public class BluetoothSerialService {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
                 mmSocket = tmp;
-//            } else {
-//                Log.d(TAG, "Creating Socket connection 222 ");
-//                try {
-//                    tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-//                } catch (IOException e) {
-//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-//                }
-//                mmSocket = tmp;
-//            }
+
         }
 
         public void run() {
             Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
             setName("ConnectThread" + mSocketType);
 
-//            if (
-//                !mmDevice.getName().contains("UA-767") &&
-//                    !mmDevice.getName().contains("UC-355") &&
-//                    !mmDevice.getName().contains("UC-351")
-//            ) {
                 // Always cancel discovery because it will slow down a connection
                 mAdapter.cancelDiscovery();
 
@@ -630,50 +472,7 @@ public class BluetoothSerialService {
                         return;
                     }
                 }
-//            } else {
-//                // for SPP..
-//                // Make a connection to the BluetoothSocket
-//                try {
-//                    // This is a blocking call and will only return on a successful connection or an exception
-//                    Log.i(TAG, "Connecting to socket...");
-//                    mmSocket.connect();
-//                    Log.i(TAG, "Connected");
-//                    connectedBlueToothDevice = mmSocket.getRemoteDevice();
-//                } catch (IOException e) {
-//                    Log.e(TAG, e.toString());
-//
-//                    // Some 4.1 devices have problems, try an alternative way to connect
-//                    // See https://github.com/don/BluetoothSerial/issues/89
-//                    try {
-//                        Log.i(TAG, "Trying fallback...");
-//                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
-//
-//                        mmSocket.connect();
-//                        Log.i(TAG, "Connected");
-//                        connectedBlueToothDevice = mmSocket.getRemoteDevice();
-//                    } catch (Exception e2) {
-//                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-//                        try {
-//                            if(mmSocket!=null) {
-//                                mmSocket.close();
-//                            }
-//
-//                        } catch (IOException e3) {
-//                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-//                        }
-//
-//                        // Send the name of the connected device back to the UI Activity
-//                        // Send a failure message back to the Activity
-//                        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-//                        Bundle bundle = new Bundle();
-//                        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
-//                        msg.setData(bundle);
-//                        mHandler.sendMessage(msg);
-//
-//                    }
-//                }
 
- //          }
             synchronized (BluetoothSerialService.this) {
                 mConnectThread = null;
             }
@@ -692,129 +491,10 @@ public class BluetoothSerialService {
         }
     }
 
-    private void connectToDevice(BluetoothSocket socket) throws IOException {
-        mmSocket = socket;
-        connectedBlueToothDevice = socket.getRemoteDevice();
-        Log.d(TAG, "bluetoothDevice CONNECTED OR NOT: " + socket.isConnected());
-        in = socket.getInputStream();
-        out = socket.getOutputStream();
-        Log.d(TAG, "out: " + out);
-    }
-//    private void readPatientInfoPacket() throws IOException{
-//        // Check the packet type...
-//        int pktType1 = in.read();
-//        int pktType2 = in.read();
-//        int pktType = pktType1 + shift(pktType2,8);
-//        Log.d(TAG,"packet type: " + pktType);
-//
-//
-//        //if packet type is not the data packet, then read in and discard header packet
-//        if (pktType != 2) {
-//            Log.d(TAG,"skipping patient info packet...");
-//            //this is a patient info packet, skip the next 28 bytes
-//            boolean packetend = false;
-//            int lookfor = 0;
-//            while (!packetend) {
-//                int b = in.read();
-//                if (b == PATIENTINFO_PACKET_HEADER[lookfor]) {
-//                    lookfor++;
-//                }
-//                else if (lookfor > 0) {
-//                    lookfor = 0;
-//                }
-//
-//                if (lookfor == PATIENTINFO_PACKET_HEADER.length) {
-//                    packetend = true;
-//                }
-//            }
-//            Log.d(TAG,"end of patient info packet found...");
-//
-//            //now start the packet read over again
-//            pktType1 = in.read();
-//            pktType2 = in.read();
-//            pktType = pktType1 + shift(pktType2,8);
-//
-//        }
-//    }
 
     public static int shift(int val, int shift){
         return (val << shift);
     }
-
-//    private int readPatientPacket() throws IOException{
-//        // Check the packet length...
-//        plen = in.read() + shift(in.read(),8) + shift(in.read(),16) + shift(in.read(),24);
-//        Log.d(TAG,"packet len: " + plen);
-//
-//        //read devtype
-//        int devType = in.read() + shift(in.read(),8);
-//        Log.d(TAG,"devtype: " + devType);
-//
-//        //get flag
-//        int flag = in.read();
-//        Log.d(TAG,"flag: " + flag);
-//
-//        //get time of measurement
-//        int myear = in.read() + shift(in.read(),8);
-//        int mmonth = in.read();
-//        int mday = in.read();
-//        int mhour = in.read();
-//        int mmin = in.read();
-//        int msec = in.read();
-//        Log.d(TAG,"measurement time: " + mday + "/" + mmonth + "/" + myear + " " + mmin + ":" + msec);
-//
-//        //get time of transmission
-//        int tyear = in.read() + shift(in.read(),8);
-//        int tmonth = in.read();
-//        int tday = in.read();
-//        int thour = in.read();
-//        int tmin = in.read();
-//        int tsec = in.read();
-//        Log.d(TAG,"transmission time: " + tday + "/" + tmonth + "/" + tyear + " " + tmin + ":" + tsec);
-//
-//        Date measurementDate=new Date();
-//        Date transmissionDate=(Date)measurementDate.clone();
-//        measurementDate.setYear(myear-1900);
-//        measurementDate.setMonth(mmonth-1);
-//        measurementDate.setDate(mday);
-//        measurementDate.setHours(mhour);
-//        measurementDate.setMinutes(mmin);
-//        measurementDate.setSeconds(msec);
-//        transmissionDate.setYear(tyear-1900);
-//        transmissionDate.setMonth(tmonth-1);
-//        transmissionDate.setDate(tday);
-//        transmissionDate.setHours(thour);
-//        transmissionDate.setMinutes(tmin);
-//        transmissionDate.setSeconds(tsec);
-//
-//        //get bluetooth id of device
-//        int id0 = in.read();
-//        int id1 = in.read();
-//        int id2 = in.read();
-//        int id3 = in.read();
-//        int id4 = in.read();
-//        int id5 = in.read();
-//        Log.d(TAG,"bluetooth id: " + id0 + ":" + id1 + ":" + id2 + ":" + id3 + ":" + id4 + ":" + id5);
-//
-//        //get device name and serial number
-//        String devnameupper = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//        String devserial = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//        String devnamelower = in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read() +
-//            "" + in.read() + "" + in.read() + "" + in.read() + "" + in.read();
-//
-//        //device battery status
-//        int batterystatus = in.read();
-//        Log.d(TAG,"battery status: " + batterystatus);
-//
-//        //skip reserved byte
-//        in.skip(1);
-//
-//        //get device firmware/hardware
-//        int devfirmwarehardware = in.read();
-//
-//        return devType;
-//    }
 
 
     public void onConnection(BluetoothSocket socket) throws IOException {
@@ -826,30 +506,6 @@ public class BluetoothSerialService {
         }
     }
 
-//    private void readData(BluetoothSocket socket, String deviceType) throws IOException{
-//        connectToDevice(socket);
-//        setState(STATE_CONNECTED);
-//        readPatientInfoPacket();
-//        int devType = readPatientPacket();
-//        Log.d(TAG, "## device type " + deviceType);
-//
-//        if(socket!=null) {
-//            BluetoothDevice connectedBTDevice = socket.getRemoteDevice(); //gives the currently connected device
-//            if(connectedBTDevice!=null) {
-//                Log.d(TAG, "## connected BT device " + connectedBTDevice.getName());
-//                connectedBlueToothDevice = connectedBTDevice;
-//            }
-//        }
-//        Log.d(TAG, " Connected device type " + connectedBlueToothDevice.getName());
-//        if(devType == 766 || connectedBlueToothDevice.getName().contains("UA-767") ) { //device keeps on getting changed, recheck device frm data obtained
-//            onBPDataPacket();
-//        } else {
-//            onScaleDataPacket();
-//        }
-//
-//        sendAcknowledgement();
-//         closeConnection();  //nehal trial
-//    }
 
     /**
      * This thread runs during a connection with a remote device.
@@ -894,13 +550,6 @@ public class BluetoothSerialService {
             while (true) {
                 try {
                     // Read from the InputStream
-//                    try {
-//                        Log.d(TAG, "Sleeping this thread for  a while " + this);
-//                        sleep(5000);
-//                    } catch (InterruptedException e) {
-//                        e.printStackTrace();
-//                    }
-
 
                     bytes = mmInStream.read(buffer);
                     String data = new String(buffer, 0, bytes);

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -75,7 +75,7 @@ public class BluetoothSerialService {
     private int dataWeightPacketSize=14; // Weight
     private Date connectionTime=null;
     private BluetoothDevice connectedBlueToothDevice;
-    private static SPPAcceptThread sppAcceptThread;
+    // private static SPPAcceptThread sppAcceptThread;
 
     public int getDataPacketLength(){return plen;}
 
@@ -128,21 +128,21 @@ public class BluetoothSerialService {
     public synchronized void start(BluetoothDevice device) {
         if (D) Log.d(TAG, "start");
 
-        if (
-            // this is specifically for the A&D devices for the SPP listener mode
-            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
-        ) {
-            resetConnectedBTDevice();
-
-            if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
-                Log.d(TAG, "## SPP thread is alive!!!");
-                sppAcceptThread.resetDevice(device);
-            } else {
-                Log.d(TAG, "## New SPP thread !!!");
-                sppAcceptThread = new SPPAcceptThread(device);
-                sppAcceptThread.start();
-            }
-        }
+//        if (
+//            // this is specifically for the A&D devices for the SPP listener mode
+//            device != null && (device.getName().contains("UA-767") || device.getName().contains("UC-355") || device.getName().contains("UC-351"))
+//        ) {
+//            resetConnectedBTDevice();
+//
+//            if (sppAcceptThread!=null && sppAcceptThread.isAlive()) {
+//                Log.d(TAG, "## SPP thread is alive!!!");
+//                sppAcceptThread.resetDevice(device);
+//            } else {
+//                Log.d(TAG, "## New SPP thread !!!");
+//                sppAcceptThread = new SPPAcceptThread(device);
+//                sppAcceptThread.start();
+//            }
+//        }
 
         // Cancel any thread attempting to make a connection
         if (mConnectThread != null) {mConnectThread.cancel(); mConnectThread = null;}
@@ -150,8 +150,20 @@ public class BluetoothSerialService {
         // Cancel any thread currently running a connection
         if (mConnectedThread != null) {mConnectedThread.cancel(); mConnectedThread = null;}
 
-        setState(STATE_NONE);
+      //  setState(STATE_NONE);
 
+
+        //        // Start the thread to listen on a BluetoothServerSocket
+//        if (mSecureAcceptThread == null) {
+//            mSecureAcceptThread = new AcceptThread(true);
+//            mSecureAcceptThread.start();
+//        }
+        if (mInsecureAcceptThread == null) {
+            mInsecureAcceptThread = new AcceptThread(false);
+            mInsecureAcceptThread.start();
+
+        }
+        setState(STATE_LISTEN);
 
     }
 
@@ -159,93 +171,93 @@ public class BluetoothSerialService {
         setState(STATE_NONE);
     }
 
-    private class SPPAcceptThread extends Thread {
-        private BluetoothServerSocket mmServerSocket;
-        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-        BluetoothDevice device;
-
-        public void resetDevice(BluetoothDevice device) {
-            Log.d(TAG, "## Resetting the device from " +  this.device.getName());
-            this.device = device;
-            Log.d(TAG, "## Resetting the device to " + device.getName());
-        }
-
-        public SPPAcceptThread(BluetoothDevice device) {
-            mmServerSocket = null;
-            this.device = device;
-            Log.d(TAG, "New SPP Accept thread for device " + device.getName());
-        }
-
-        public void run() {
-            BluetoothSocket socket = null;
-            // Keep listening until exception occurs or a socket is returned
-            try {
-                Log.i(TAG, "getting socket from adapter");
-                mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
-
-
-                while (true/* mState != STATE_CONNECTED*/) {
-                    try {
-                        Log.d(TAG, "----- > SPP accept thread ---> ");
-
-                        socket = mmServerSocket.accept();
-                    } catch (IOException e) {
-                        Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
-                    }
-
-                    // If a connection was accepted
-                    if (socket != null) {
-                        //synchronized (BluetoothSerialService.this) {
-                        // Do work to manage the connection (in a separate thread)
-                        try {
-                            Log.d(TAG, " -- > SPP thread --> connection accepted -- > ");
-                            BluetoothDevice btDevice = this.device; //device;
-                            String deviceType = "";
-                            try {
-                                String deviceAddr = btDevice.getAddress();
-                                //found connected device profile, get results
-                                Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
-                                if (btDevice.getName().contains("UA-767")) {
-                                    deviceType = "bloodpressure";
-                                } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351")) {
-                                    deviceType = "scale";
-                                }
-                                onConnection(socket);
-                                readData(socket, deviceType);
-                            } catch (Exception e) {
-                                Log.d(TAG, "Error finding bluetooth device" + e);
-                            }
-                        } catch (Exception e) {
-                            Log.d(TAG, "Bluetooth Socket Error", e);
-                        }
-                        try {
-                            if(mmServerSocket!=null) {
-                                mmServerSocket.close();
-                            }
-                        } catch (IOException exception) {
-                            exception.printStackTrace();
-                        }
-                        break;
-                    }
-
-                }
-
-
-            }
-            catch (IOException ex) {
-                Log.e(TAG, "error while initializing");
-            }
-        }
-
-        /** Will cancel the listening socket, and cause the thread to finish */
-        public void cancel() {
-            try {
-                if(mmServerSocket!=null) {
-                    mmServerSocket.close();
-                }
-            } catch (IOException e) { }
-        }
-    }
+//    private class SPPAcceptThread extends Thread {
+//        private BluetoothServerSocket mmServerSocket;
+//        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+//        BluetoothDevice device;
+//
+//        public void resetDevice(BluetoothDevice device) {
+//            Log.d(TAG, "## Resetting the device from " +  this.device.getName());
+//            this.device = device;
+//            Log.d(TAG, "## Resetting the device to " + device.getName());
+//        }
+//
+//        public SPPAcceptThread(BluetoothDevice device) {
+//            mmServerSocket = null;
+//            this.device = device;
+//            Log.d(TAG, "New SPP Accept thread for device " + device.getName());
+//        }
+//
+//        public void run() {
+//            BluetoothSocket socket = null;
+//            // Keep listening until exception occurs or a socket is returned
+//            try {
+//                Log.i(TAG, "getting socket from adapter");
+//                mmServerSocket = adapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
+//
+//
+//                while (true/* mState != STATE_CONNECTED*/) {
+//                    try {
+//                        Log.d(TAG, "----- > SPP accept thread ---> ");
+//
+//                        socket = mmServerSocket.accept();
+//                    } catch (IOException e) {
+//                        Log.d(TAG, "IO EXCEPTION -----------SPP ACCEPT--------- " + e.getMessage());
+//                    }
+//
+//                    // If a connection was accepted
+//                    if (socket != null) {
+//                        //synchronized (BluetoothSerialService.this) {
+//                        // Do work to manage the connection (in a separate thread)
+//                        try {
+//                            Log.d(TAG, " -- > SPP thread --> connection accepted -- > ");
+//                            BluetoothDevice btDevice = this.device; //device;
+//                            String deviceType = "";
+//                            try {
+//                                String deviceAddr = btDevice.getAddress();
+//                                //found connected device profile, get results
+//                                Log.d(TAG, "Bluetooth device found, processing data..." + btDevice.getName());
+//                                if (btDevice.getName().contains("UA-767")) {
+//                                    deviceType = "bloodpressure";
+//                                } else if (btDevice.getName().contains("UC-355") || btDevice.getName().contains("UC-351")) {
+//                                    deviceType = "scale";
+//                                }
+//                                onConnection(socket);
+//                                readData(socket, deviceType);
+//                            } catch (Exception e) {
+//                                Log.d(TAG, "Error finding bluetooth device" + e);
+//                            }
+//                        } catch (Exception e) {
+//                            Log.d(TAG, "Bluetooth Socket Error", e);
+//                        }
+//                        try {
+//                            if(mmServerSocket!=null) {
+//                                mmServerSocket.close();
+//                            }
+//                        } catch (IOException exception) {
+//                            exception.printStackTrace();
+//                        }  //nehal trail
+//                        break;
+//                    }
+//
+//                }
+//
+//
+//            }
+//            catch (IOException ex) {
+//                Log.e(TAG, "error while initializing");
+//            }
+//        }
+//
+//        /** Will cancel the listening socket, and cause the thread to finish */
+//        public void cancel() {
+//            try {
+//                if(mmServerSocket!=null) {
+//                    mmServerSocket.close();
+//                }
+//            } catch (IOException e) { }
+//        }
+//    }
 
     /**
      * Start the ConnectThread to initiate a connection to a remote device.
@@ -298,11 +310,11 @@ public class BluetoothSerialService {
 
 
         // Start the thread to manage the connection and perform transmissions
-        if (
-            !device.getName().contains("UA-767") &&
-                !device.getName().contains("UC-355") &&
-                !device.getName().contains("UC-351")
-        ) {
+//        if (
+//            !device.getName().contains("UA-767") &&
+//                !device.getName().contains("UC-355") &&
+//                !device.getName().contains("UC-351")
+//        ) {
             mConnectedThread = new ConnectedThread(socket, socketType, device);
             mConnectedThread.start();
 
@@ -313,8 +325,8 @@ public class BluetoothSerialService {
             msg.setData(bundle);
             mHandler.sendMessage(msg);
 
-        }
-        setState(STATE_CONNECTED);
+  //     }
+      setState(STATE_CONNECTED);
 
     }
 
@@ -403,24 +415,26 @@ public class BluetoothSerialService {
      */
     private class AcceptThread extends Thread {
         // The local server socket
-        private final BluetoothServerSocket mmServerSocket;
+        private /*final*/ BluetoothServerSocket mmServerSocket;
         private String mSocketType;
 
         public AcceptThread(boolean secure) {
             BluetoothServerSocket tmp = null;
             mSocketType = secure ? "Secure":"Insecure";
-
-            // Create a new listening server socket
+            Log.d(TAG, "Accept thread" + mSocketType);
+//            // Create a new listening server socket
             try {
-                if (secure) {
-                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);
-                } else {
-                    tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
-                }
+//                if (secure) {
+//                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);
+//                } else {
+//                    tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord(NAME_INSECURE, MY_UUID_INSECURE);
+//                }
+                tmp = mAdapter.listenUsingInsecureRfcommWithServiceRecord("PWAccessP", UUID_SPP);
             } catch (IOException e) {
                 Log.e(TAG, "Socket Type: " + mSocketType + "listen() failed", e);
             }
             mmServerSocket = tmp;
+
         }
 
         public void run() {
@@ -428,6 +442,7 @@ public class BluetoothSerialService {
             setName("AcceptThread" + mSocketType);
 
             BluetoothSocket socket;
+
 
             // Listen to the server socket if we're not connected
             while (mState != STATE_CONNECTED) {
@@ -447,6 +462,7 @@ public class BluetoothSerialService {
                             case STATE_LISTEN:
                             case STATE_CONNECTING:
                                 // Situation normal. Start the connected thread.
+                                Log.d(TAG, "Calling accept thread connect ----------");
                                 connected(socket, socket.getRemoteDevice(),
                                     mSocketType);
                                 break;
@@ -503,41 +519,43 @@ public class BluetoothSerialService {
             }
 
             // Get a BluetoothSocket for a connection with the given BluetoothDevice
-            if (
-                !device.getName().contains("UA-767") &&
-                    !device.getName().contains("UC-355") &&
-                    !device.getName().contains("UC-351")
-            ) {
+//            if (
+//                !device.getName().contains("UA-767") &&
+//                    !device.getName().contains("UC-355") &&
+//                    !device.getName().contains("UC-351")
+//            ) {
+                Log.d(TAG, "Creating Socket connection 111 ");
                 // Get a BluetoothSocket for a connection with the given BluetoothDevice
                 try {
-                    if (secure) {
-                        tmp = device.createRfcommSocketToServiceRecord(UUID_SPP);
-                    } else {
+//                    if (secure) {
+//                        tmp = device.createRfcommSocketToServiceRecord(UUID_SPP);
+//                    } else {
                         tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-                    }
+                   // }
                 } catch (IOException e) {
                     Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
                 }
                 mmSocket = tmp;
-            } else {
-                try {
-                    tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
-                } catch (IOException e) {
-                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
-                }
-                mmSocket = tmp;
-            }
+//            } else {
+//                Log.d(TAG, "Creating Socket connection 222 ");
+//                try {
+//                    tmp = device.createInsecureRfcommSocketToServiceRecord(UUID_SPP);
+//                } catch (IOException e) {
+//                    Log.e(TAG, "Socket Type: " + mSocketType + "create() failed", e);
+//                }
+//                mmSocket = tmp;
+//            }
         }
 
         public void run() {
             Log.i(TAG, "BEGIN mConnectThread SocketType:" + mmDevice);
             setName("ConnectThread" + mSocketType);
 
-            if (
-                !mmDevice.getName().contains("UA-767") &&
-                    !mmDevice.getName().contains("UC-355") &&
-                    !mmDevice.getName().contains("UC-351")
-            ) {
+//            if (
+//                !mmDevice.getName().contains("UA-767") &&
+//                    !mmDevice.getName().contains("UC-355") &&
+//                    !mmDevice.getName().contains("UC-351")
+//            ) {
                 // Always cancel discovery because it will slow down a connection
                 mAdapter.cancelDiscovery();
 
@@ -571,50 +589,50 @@ public class BluetoothSerialService {
                         return;
                     }
                 }
-            } else {
-                // for SPP..
-                // Make a connection to the BluetoothSocket
-                try {
-                    // This is a blocking call and will only return on a successful connection or an exception
-                    Log.i(TAG, "Connecting to socket...");
-                    mmSocket.connect();
-                    Log.i(TAG, "Connected");
-                    connectedBlueToothDevice = mmSocket.getRemoteDevice();
-                } catch (IOException e) {
-                    Log.e(TAG, e.toString());
+//            } else {
+//                // for SPP..
+//                // Make a connection to the BluetoothSocket
+//                try {
+//                    // This is a blocking call and will only return on a successful connection or an exception
+//                    Log.i(TAG, "Connecting to socket...");
+//                    mmSocket.connect();
+//                    Log.i(TAG, "Connected");
+//                    connectedBlueToothDevice = mmSocket.getRemoteDevice();
+//                } catch (IOException e) {
+//                    Log.e(TAG, e.toString());
+//
+//                    // Some 4.1 devices have problems, try an alternative way to connect
+//                    // See https://github.com/don/BluetoothSerial/issues/89
+//                    try {
+//                        Log.i(TAG, "Trying fallback...");
+//                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
+//
+//                        mmSocket.connect();
+//                        Log.i(TAG, "Connected");
+//                        connectedBlueToothDevice = mmSocket.getRemoteDevice();
+//                    } catch (Exception e2) {
+//                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
+//                        try {
+//                            if(mmSocket!=null) {
+//                                mmSocket.close();
+//                            }
+//
+//                        } catch (IOException e3) {
+//                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
+//                        }
+//
+//                        // Send the name of the connected device back to the UI Activity
+//                        // Send a failure message back to the Activity
+//                        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
+//                        Bundle bundle = new Bundle();
+//                        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
+//                        msg.setData(bundle);
+//                        mHandler.sendMessage(msg);
+//
+//                    }
+//                }
 
-                    // Some 4.1 devices have problems, try an alternative way to connect
-                    // See https://github.com/don/BluetoothSerial/issues/89
-                    try {
-                        Log.i(TAG, "Trying fallback...");
-                        mmSocket = (BluetoothSocket) mmDevice.getClass().getMethod("createRfcommSocket", new Class[]{int.class}).invoke(mmDevice, 1);
-
-                        mmSocket.connect();
-                        Log.i(TAG, "Connected");
-                        connectedBlueToothDevice = mmSocket.getRemoteDevice();
-                    } catch (Exception e2) {
-                        Log.e(TAG, "Couldn't establish a Bluetooth connection.");
-                        try {
-                            if(mmSocket!=null) {
-                                mmSocket.close();
-                            }
-
-                        } catch (IOException e3) {
-                            Log.e(TAG, "unable to close() " + mSocketType + " socket during connection failure", e3);
-                        }
-
-                        // Send the name of the connected device back to the UI Activity
-                        // Send a failure message back to the Activity
-                        Message msg = mHandler.obtainMessage(BluetoothSerial.MESSAGE_TOAST);
-                        Bundle bundle = new Bundle();
-                        bundle.putString(BluetoothSerial.TOAST, "Unable to connect to device");
-                        msg.setData(bundle);
-                        mHandler.sendMessage(msg);
-
-                    }
-                }
-
-            }
+ //          }
             synchronized (BluetoothSerialService.this) {
                 mConnectThread = null;
             }
@@ -789,7 +807,7 @@ public class BluetoothSerialService {
         }
 
         sendAcknowledgement();
-        closeConnection();
+         closeConnection();  //nehal trial
     }
 
     /**
@@ -820,10 +838,12 @@ public class BluetoothSerialService {
 
             mmInStream = tmpIn;
             mmOutStream = tmpOut;
+            Log.d(TAG, "mmInStream " + mmInStream);
+            Log.d(TAG, "mmInStream " + mmInStream);
         }
 
         public void run() {
-            Log.d(TAG, "ConnectedThread reading bytes");
+            Log.d(TAG, "ConnectedThread RUN reading bytes");
             byte[] buffer = new byte[1024];
             int bytes;
 
@@ -840,16 +860,20 @@ public class BluetoothSerialService {
                     // Send the raw bytestream to the UI Activity.
                     // We make a copy because the full array can have extra data at the end
                     // when / if we read less than its size.
+                    Log.d(TAG, "ConnectedThread RUN reading bytes SIZE " + bytes);
                     if (bytes > 0) {
                         byte[] rawdata = Arrays.copyOf(buffer, bytes);
                         mHandler.obtainMessage(BluetoothSerial.MESSAGE_READ_RAW, rawdata).sendToTarget();
                     }
+
+
 
                 } catch (IOException e) {
                     Log.e(TAG, "disconnected", e);
                     connectionLost();
                     // Start the service over to restart listening mode
                     BluetoothSerialService.this.start(btDevice);
+
                     break;
                 }
             }
@@ -948,7 +972,7 @@ public class BluetoothSerialService {
     private void sendAcknowledgement(){
         //now send response to acknowledge
         try{
-            String msg = "PWA1";
+            String msg = "PWA4"; // "PWA1"; //PWA4 to send data accpet without disconnet
             byte[] send = msg.getBytes();
             out.write(send);
             out.flush();

--- a/src/android/com/megster/cordova/BluetoothSerialService.java
+++ b/src/android/com/megster/cordova/BluetoothSerialService.java
@@ -122,6 +122,9 @@ public class BluetoothSerialService {
     }
 
 
+
+
+
     /**
      * Start the chat service. Specifically start AcceptThread to begin a
      * session in listening (server) mode. Called by the Activity onResume() */
@@ -423,6 +426,7 @@ public class BluetoothSerialService {
             mSocketType = secure ? "Secure":"Insecure";
             Log.d(TAG, "Accept thread" + mSocketType);
 //            // Create a new listening server socket
+            /// this should work based on device type TBD
             try {
 //                if (secure) {
 //                    tmp = mAdapter.listenUsingRfcommWithServiceRecord(NAME_SECURE, MY_UUID_SECURE);

--- a/www/bluetoothSerial.js
+++ b/www/bluetoothSerial.js
@@ -129,8 +129,11 @@ module.exports = {
 
     setDiscoverable: function (discoverableDuration) {
         cordova.exec(null, null, "BluetoothSerial", "setDiscoverable", [discoverableDuration]);
-    }
+    },
 
+    unPairDevice: function (macAddress, success, failure) {
+        cordova.exec(success, failure, "BluetoothSerial", "unPairDevice", [macAddress]);
+    }
 
 };
 


### PR DESCRIPTION
This MR address the following changes for Bluetooth Serial plugin :

**Parsing code cleanup:**
- Moved all the parsing code from Serial plugin to PCMT layer. This has helped us to gather logs and info from classic devices. 

- We are now subscribing for raw data for all the AnD classic devices. 

**SPP and Accept Thread Changes**
- Changes have been made to SPP thread related to connection and pairing for Serial Port Profile BT device. These have fixed connection and pairing related problems for AnD classic devices. 

**Handling of early data fetch scenario for classic devices**
- For devices such as Classic AnD 767 and 355, as soon as the device was turned on, if there was any stored data onto it, it started sending the readings as soon as connection with the device was being made. Until that time, our app was not subscribing to read any data thus the data from devices was getting lost. This MR fixes this scenario as well. 

**Addition of unPairDevice to classic plugin**
- Also added 'unPairDevice()' functionality to actually remove bond of an already paired classic device. 