### PR TITLE
DEV-15384 : Added methods for canceling discovery and providing device types

### DIFF
--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import timber.log.Timber;
+
 /**
  * PhoneGap Plugin for Serial Communication over Bluetooth
  */
@@ -543,8 +545,13 @@ public class BluetoothSerial extends CordovaPlugin {
 
         filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
         activity.registerReceiver(discoverReceiver, filter);
-
-        bluetoothAdapter.startDiscovery();
+        // Do not start a new discovery if we already have an ongoing one
+        if(!bluetoothAdapter.isDiscovering()) {
+            Timber.v("Will start BT device discovery");
+            bluetoothAdapter.startDiscovery();
+        } else {
+            Timber.v("BT adapter is discovering hence not will not start a scan");
+        }
     }
 
     private JSONObject deviceToJSON(BluetoothDevice device) throws JSONException {
@@ -554,6 +561,20 @@ public class BluetoothSerial extends CordovaPlugin {
             json.put("name", device.getName());
             json.put("address", device.getAddress());
             json.put("id", device.getAddress());
+            int deviceType = device.getType();
+
+            if(deviceType == BluetoothDevice.DEVICE_TYPE_CLASSIC)
+            {
+                json.put("type", "DEVICE_TYPE_CLASSIC");
+            }
+            else if(deviceType == BluetoothDevice.DEVICE_TYPE_LE)
+            {
+                json.put("type", "DEVICE_TYPE_LE");
+            }
+            else if(deviceType == BluetoothDevice.DEVICE_TYPE_DUAL)
+            {
+                json.put("type", "DEVICE_TYPE_DUAL");
+            }
             if (device.getBluetoothClass() != null) {
                 json.put("class", device.getBluetoothClass().getDeviceClass());
             }

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -317,12 +317,15 @@ public class BluetoothSerial extends CordovaPlugin {
             cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
 
         } else if (action.equals(DISCOVER_UNPAIRED)) {
-
-            if (hasBluetoothPermissions()) {
-                discoverUnpairedDevices(callbackContext);
+            if (!isDeviceDiscoveryOn()) {
+                if (hasBluetoothPermissions()) {
+                    discoverUnpairedDevices(callbackContext);
+                } else {
+                    permissionCallback = callbackContext;
+                    requestPermissions();
+                }
             } else {
-                permissionCallback = callbackContext;
-                requestPermissions();
+                Timber.v("Device discovery in progress, not starting it again");
             }
 
         } else if (action.equals(SET_DEVICE_DISCOVERED_LISTENER)) {
@@ -551,11 +554,15 @@ public class BluetoothSerial extends CordovaPlugin {
         activity.registerReceiver(discoverReceiver, filter);
         // Do not start a new discovery if we already have an ongoing one
         if(!bluetoothAdapter.isDiscovering()) {
-            Timber.v("Will start BT device discovery");
             bluetoothAdapter.startDiscovery();
+            Timber.v("Will start BT device discovery");
         } else {
             Timber.v("BT adapter is discovering hence not will not start a scan");
         }
+    }
+
+    private boolean isDeviceDiscoveryOn() {
+        return bluetoothAdapter!=null && bluetoothAdapter.isDiscovering();
     }
 
     private void cancelDiscovery() {

--- a/src/android/com/megster/cordova/BluetoothSerial.java
+++ b/src/android/com/megster/cordova/BluetoothSerial.java
@@ -66,6 +66,7 @@ public class BluetoothSerial extends CordovaPlugin {
     private static final String SET_NAME = "setName";
     private static final String SET_DISCOVERABLE = "setDiscoverable";
     private static final String UNPAIR_DEVICE ="unPairDevice";
+    private static final String CANCEL_DISCOVERY = "cancelDiscovery";
 
     // callbacks
     private CallbackContext connectCallback;
@@ -349,7 +350,10 @@ public class BluetoothSerial extends CordovaPlugin {
             Log.d(TAG, "unpair devic called -- ");
             unPairDevice(args, callbackContext);
 
-        } else {
+        } else if (action.equals(CANCEL_DISCOVERY)) {
+            cancelDiscovery();
+        }
+        else {
             validAction = false;
 
         }
@@ -551,6 +555,16 @@ public class BluetoothSerial extends CordovaPlugin {
             bluetoothAdapter.startDiscovery();
         } else {
             Timber.v("BT adapter is discovering hence not will not start a scan");
+        }
+    }
+
+    private void cancelDiscovery() {
+        if(bluetoothAdapter!=null) {
+            if(bluetoothAdapter.isDiscovering()) {
+                Timber.v("Canceling device discovery");
+                bluetoothAdapter.cancelDiscovery();
+                this.deviceDiscoveredCallback = null; // clearing device discovered callback
+            }
         }
     }
 

--- a/www/bluetoothSerial.js
+++ b/www/bluetoothSerial.js
@@ -133,6 +133,10 @@ module.exports = {
 
     unPairDevice: function (macAddress, success, failure) {
         cordova.exec(success, failure, "BluetoothSerial", "unPairDevice", [macAddress]);
+    },
+    
+    cancelDiscovery: function () {
+        cordova.exec(success, failure, "BluetoothSerial", "cancelDiscovery", []);
     }
 
 };

--- a/www/bluetoothSerial.js
+++ b/www/bluetoothSerial.js
@@ -136,7 +136,7 @@ module.exports = {
     },
     
     cancelDiscovery: function () {
-        cordova.exec(success, failure, "BluetoothSerial", "cancelDiscovery", []);
+        cordova.exec(null, null, "BluetoothSerial", "cancelDiscovery", []);
     }
 
 };


### PR DESCRIPTION
In this MR, we have done the following to achieve a smoother device discovery experience when user is trying to pair a device:
- When a device discovery is on (we are trying to find out unpaired devices with the help of discoverUnpaired, applied check of not to start the discovery again. 
- Added cancelDiscovery method to cancel an ongoing device discovery